### PR TITLE
Feat: scope pip shader support

### DIFF
--- a/docs/SCOPE_PIP_HANDOFF_2026_08_21.md
+++ b/docs/SCOPE_PIP_HANDOFF_2026_08_21.md
@@ -1,0 +1,531 @@
+# 瞄准镜镜内画中画（Scope PIP）· 会话交接
+
+**日期**：2026-08-21（凌晨，接续 08-19 夜间会话）
+**分支**：`26.2(main)`
+**当前 jar**：`build/libs/TACZ-Refabricated-26.2-1.1.8+fabric.26.2.R2.jar`（05:3x 构建，`./gradlew build` 通过）
+
+> ⚠️ **实测前务必确认 `mods/` 里那个 jar 就是刚构建的那个。**
+> 08-21 有整整两个会话（47366 + 4074 条报错）是在追一个已经改过、但 jar 没换的问题上浪费的；
+> 更早还有一次 R1 盖住 R2。日志里认这一行：`- tacz 1.1.8+fabric.26.2.R2`，
+> 再对一眼 `mods/` 里 jar 的时间戳。
+
+> 本文用于**新会话冷启动**。读完这一篇就能接着干，不必回看聊天记录。
+> 按 `AGENTS.md` §2：**已实测**与**推导未验证**分开标注，不写没验证过的结论。
+
+---
+
+## 0. 一句话现状
+
+| 环境 | 状态 |
+|---|---|
+| **无光影** | ✅ **完全可用**。镜外 1×、镜内原生分辨率放大、无溢出、地形正确 |
+| **开光影（Iris）** | 🟡 **代码完成、编译通过、待实机验证**。已换成<b>屏幕空间</b>方案（§2.3e）：等 Iris 整条管线画完，直接在最终画面上放大。不再依赖任何 pack 的 colortex 约定 |
+
+**默认配置是安全的**：`ScopePipEnable=false`。玩家不动配置 = 与本次改动前完全一致。
+
+> **读本文的顺序**：光影路径只看 **§2.3e**（当前方案）。
+> §2.1–2.3d 全是已被推翻的历史，保留是为了「别再走第四遍」，不是现状描述。
+
+> **04:1x 已修的一个回归**（曾表现为「Voxy 坏了」）：shader 注入里的 `colortex1` 前缀撞名
+> 会让 pack 编译失败、Iris 整体禁用光影。详见 §2.6。
+> **§2.3e 之后注入里已经完全不出现 `colortex`，这类事故从根上消失。**
+
+---
+
+## 1. 无光影路径：做完了，别动
+
+### 1.1 最终形态
+
+`ScopePipRerender=true` 时：用**窄 FOV 把世界再渲染一遍**到离屏 target，
+再由目镜掩码把这张原生分辨率的图贴进镜片。镜外世界 FOV 完全不动。
+
+关键实现点（都踩过坑，改之前先读注释）：
+
+| 文件 | 作用 |
+|---|---|
+| `client/render/scope/ScopePipRenderer.java` | 判定闸门、二次渲染、合成 |
+| `client/render/scope/ScopePipTarget.java` | 离屏 target 生命周期 |
+| `compat/sodium/SodiumCompat.java` | **两处** Sodium 状态同步（见 §1.2，最关键） |
+| `mixin/client/GameRendererMixin.java` | 帧状态归零、二次渲染注入、`mainRenderTarget()` 重定向 |
+| `mixin/client/SkyRendererMixin.java` | 天空渲染跟随重定向（它缓存了 target） |
+| `assets/tacz/shaders/core/scope_pip.fsh` | 合成着色器（重投影模式用） |
+
+### 1.2 【最重要】那个折腾了整晚的「溢出」根本不是溢出
+
+症状：镜内正常，但**镜外**的近处水面、冰柱被拉伸放大，远处地形却正常。
+
+真因：**Sodium 每帧只上传一次区块投影**。
+
+```java
+// UniformBufferManager.update  (字节码实读)
+public void update(ChunkRenderMatrices m, FogParameters fog) {
+    if (this.hasUpdatedThisFrame) return;   // ← 偏移 0-7
+    this.hasUpdatedThisFrame = true;
+    ... 上传 m.projection() ...
+}
+public void prepareFrame() { this.hasUpdatedThisFrame = false; }
+```
+
+镜内那一遍**先到**，带着窄 FOV 上传成功并把闸关上；随后 vanilla 那一遍带正常矩阵调
+`update()` 时**直接 return**。于是主画面里 Sodium 的地形全部用镜内的窄投影绘制。
+远处地形归 Voxy LOD（另一套 uniform 通路）管，所以看着正常 —— 那个「远近差异」
+正是这条的签名。
+
+**修法**：两遍之间调 Sodium 自己的 public `prepareFrame()` 把闸重新打开
+（`SodiumCompat.resetChunkUniformUpload()`，放在 `finally` 里）。
+
+> **教训**：症状对上不等于归因对上。「地形没跟着放大」既能由「渲染目标没跟随」解释，
+> 也能由「投影/uniform 没跟随」解释，画面上完全一样。整晚有 6 次误判都源于此。
+
+### 1.3 其余已修的真 bug
+
+- **Sodium 投影快照**：Sodium 用 `GameRendererStorage.sodium$getProjectionMatrix()`
+  自己那份，**不看** `RenderSystem.setProjectionMatrix`。→ `SodiumCompat.overrideProjection()`。
+- **`SkyRenderer` 缓存 target**：全客户端只有它把 `mainRenderTarget()` 存成
+  `private final` 字段，重定向对它无效。→ `SkyRendererMixin` 改字段**读取**表达式。
+  （已核对：`ChunkSectionLayerGroup`、`CloudRenderer`、`QuadParticleFeatureRenderer`、
+  `WorldBorderRenderer`、`OutputTarget`、Sodium `TerrainRenderPass` 全是每次现问，不受影响。）
+- **掩码标志被 Iris 双手部 pass 抹掉**：Iris `HandRenderer` 一帧调两次
+  `renderAllFeatures`（`renderSolid` + `renderTranslucent`），旧实现每次手部 pass 都清零，
+  于是帧末恒为 false。→ 改为每帧在 `GameRenderer#extract` HEAD 清一次
+  （`ScopeMaskRenderer.beginFrame()`），并区分 `hasMaskThisFrame` / `hadMaskLastFrame`。
+- **凸包近平面炸包**：目镜顶点擦过近平面时 w≈0.001，NDC 飙到 ±1000，凸包撑满全屏。
+  → `NDC_SANITY_LIMIT = 2.0` 过滤。
+- **合成硬件剪裁**：按目镜屏幕包围盒开 scissor，掩码失效时也不会整屏糊上去。
+
+---
+
+## 2. 光影路径：卡在哪，已排除什么
+
+> ⚠️ **§2.1 – §2.3d 是历史记录，不是现状。** 当前方案见 **§2.3e**。
+> 这几节描述的「在 pack 着色器里采样 colortex 输出颜色」已整体删除。
+
+### 2.1 【历史】曾经的实现
+
+**纯 shader 源码注入**，在 `IrisShaderCreatorMixin` 里改 pack 的片元着色器字符串。
+**全程内存操作，不碰磁盘上的 `.zip`**（用户明确要求：只许改本仓库的文件）。
+
+模式约定（`tacz_ScopeMaskMode`，由 `IrisScopeMaskState` 逐 draw 设置）：
+
+| 模式 | 语义 |
+|---|---|
+| 0 | 关闭 |
+| 1 | 镜身：孔径**内** discard（透视镜片，原有功能） |
+| 2 | 准星：孔径**外** discard |
+| 3 | ~~镜身：孔径内输出放大后的世界~~ —— **已从代码中删除**，见 §2.3e |
+
+### 2.2 已验证可用的部分（实测）
+
+黑色八边形那次截图证明了**机制本身全通**：
+- 注入能编译进真实 shaderpack（Eclipse-Shader-Unstable）；
+- 模式经 `IrisScopeMaskState` 正确送达着色器；
+- **掩码精确定义了镜片形状**；
+- **写出去的颜色能到屏幕上**（这是外部所有尝试都做不到的）。
+
+### 2.3 唯一的缺口
+
+> **2026-08-21 04:1x 更新**：探针此前**从来没能跑起来**，有两个独立原因，均已修：
+> 1. 闸门 `tacz_ScopePipZoom < 0.0` 恒不成立 —— 唯一写这个 uniform 的
+>    `IrisScopeMaskState` 送的是 `magnification()`，被 `Math.max(1.0f, …)` 夹过；
+>    而 `ScopePipBridge.paintLensDebug()` **一个调用方都没有**。
+> 2. 见 §2.6：网格代码把整个 shaderpack 编译弄挂了。
+>
+> 现在探针改成**链接期**开关（`tacz$probeEnabled()`）：关着时整段网格不生成。
+> 因此**改完 `ScopePipDebugPaintLens` 必须重载一次 shaderpack（R 键）才生效**。
+> 日志会打印 `colortex probe grid: ON/off`，照着确认。
+
+
+`texture(colortex0, uv)` 在手部着色器里**采样结果是黑的**。也就是说：
+手部阶段 `colortex0` 里没有已着色的场景。
+
+**下一步就是找出哪张 colortex 有场景。** 03:37 那版已经写好了探针：
+`ScopePipDebugPaintLens=true` 时把孔径切成 4×2 网格，
+每格采样一张不同的 `colortex0..7`（**通过 Iris 亲自绑定的采样器**，
+不是外部反射拿的纹理 id）。哪一格有画面，哪张就是要读的。
+
+> ⚠️ 这个探针**还没跑过** —— 跑之前撞上了 §2.5 的崩溃。
+
+### 2.3b 【04:3x 已定性】黑镜片的真因是**阶段顺序**，不是采样错了 colortex
+
+反编译 Iris 1.11.2 实读，三条互相独立的证据：
+
+```
+MixinLevelRenderer.iris$beginTranslucents:
+    偏移 51  HandRenderer.renderSolid(...)      ← 镜身在这里画
+    偏移 69  pipeline.beginTranslucents()
+IrisRenderingPipeline.beginTranslucents():
+    copyPreTranslucentDepth();
+    deferredRenderer.renderAll();               ← 延迟光照在这里才跑
+```
+
+1. `gbuffers_hand`（HAND_CUTOUT）跑在延迟光照**之前** ⇒ 那一刻
+   **没有任何 colortex 装着已着色的场景**，取哪张都是黑的。
+   **§2.3 的八格探针即使跑起来也找不到答案** —— 八个格子里根本没有正确答案。
+2. `MixinItemInHandRenderer.iris$skipTranslucentHands`：
+   `isRenderingSolid() == isHandTranslucent(stack)` 时 `ci.cancel()`。
+   枪不是 `BlockItem` ⇒ `isHandTranslucent` 恒 false ⇒ 枪**只在 solid pass 提交**。
+3. 08-21 日志：`HAND_TRANSLUCENT`/`HAND_WATER` 出现 **0 次**，
+   六条 tacz 管线全部只解析到 `HAND_CUTOUT`。与 1、2 完全吻合。
+
+**已落地**：`IrisScopeMaskState` 里镜身通道恒返回 1（原为「开 PIP 就返回 3」）。
+模式 3 在 HAND_CUTOUT 下采样 colortex0 正是黑镜片的成因；
+恒 1 让镜片退化成**透视 1×**而不是纯黑 —— 这也是后续方案失败时的安全底线。
+
+### 2.3e 【当前方案 · 05:2x】屏幕空间：等 Iris 画完，直接在最终画面上放大
+
+> **2.3c / 2.3d 那条「在 pack 的着色器里采样 colortex」的路已整体放弃并从代码中删除。**
+> 下面两节保留为路标，说明它为什么走不通 —— 别再走第三遍。
+
+**核心转变**：不再试图在 Iris 管线<b>内部</b>取素材，
+而是等它**整条跑完**，在最终画面上做屏幕空间放大。
+
+#### 为什么这条路不再需要任何猜测
+
+| | 着色器内采样（已废弃） | 屏幕空间（当前） |
+|---|---|---|
+| 素材来自 | 某张 `colortexN`，**逐 pack 不同** | Iris 的**最终画面**，全局唯一 |
+| 要不要猜 | 要（Eclipse=2，别家未知） | **不要** |
+| 颜色是否与镜外一致 | 不保证（可能是中间态、线性空间） | **逐字节同源，必然一致** |
+| 炸包风险 | 高（补 colortex 声明曾整体禁用光影） | **零**（注入里不再出现 colortex 三个字） |
+
+#### 关键：镜内为什么不会出现一把缩小的枪
+
+这是整条路能成立的支点。镜身在孔径内是 `discard` 的（模式 1），
+所以**最终画面里孔径那一块就是干净的 1× 世界**，没有枪。
+而重投影采样点是 `center + (uv-center)/Z`：`uv` 取遍孔径时，
+采样点只覆盖以屏幕中心为原点、半径缩到 `1/Z` 的一小块 —— **整个落在孔径内部**。
+于是采到的全是干净的世界像素。
+
+（无光影那条路必须在 `renderItemInHand` <b>之前</b>抓图，正是因为它没有这个性质。）
+
+#### 倍率跟着开镜进度走
+
+抬镜过程中瞄具还没移到屏幕中心，而采样点恒定绕屏幕中心收缩，
+此时那一小块可能还压在枪身上 —— 直接给满倍率会让镜内闪过一段放大的枪。
+
+改用 `1 + (Z-1)·progress`：`progress→0` 时倍率→1，采样点 == 当前像素本身，
+合成结果与底下已经画好的 1× 画面**逐像素相同**，肉眼零变化；
+瞄具归位时才到满倍率。顺带与整屏变焦那条老路的公式一致，过渡手感也对得上。
+
+#### 落点
+
+| 文件 | 改动 |
+|---|---|
+| `GameRendererMixin` | 在既有的「`LevelRenderer#render` 之后」注入点追加 `compositeAfterLevelUnderShaders()`。**光影下这一点的含义变了**：Iris 把手部渲染搬进了 `LevelRenderer#render` 内部，所以此刻延迟光照、composite、色调映射、手部**全部跑完** |
+| `ScopePipRenderer` | 新增 `compositeAfterLevelUnderShaders()`；合成本体抽成共用的 `runComposite(magnification)`；`captureScene` 在光影下不再让开 |
+| `IrisScopeMaskState` | 镜身通道恒为 1（只 discard，不写颜色） |
+| `IrisShaderCreatorMixin` | **删掉**模式 3、colortex 声明、探针网格、输出变量解析。注入只剩 discard |
+
+#### 顺带的两个收益
+
+1. **注入里不再出现 `colortex`**，`undefined variable "colortex1"` → 光影被禁用 →
+   Voxy 视口全 0 那一类事故**从根上消失**。
+2. 不再需要解析 pack 的输出变量名（`tacz$findFragmentOutput`），
+   于是**那些解析不出输出变量的 pack 现在也能有目镜掩码**了 —— 以前是整段放弃注入。
+
+#### 已知代价
+
+镜内实际只由孔径内 `1/Z` 那一小块像素放大而来，高倍镜下会明显变软 ——
+与重投影模式同一个上限（IMPLEMENTATION 文档 §3）。
+换来的是**一定出图、颜色一定对、不依赖任何 pack 约定**。
+
+---
+
+### 2.3c 【已废弃 · 保留为路标】把枪挪进半透明手部 pass
+
+由 §2.3b 第 2 条反推：**只要 `isHandTranslucent(枪)` 返回 true**，
+`iris$skipTranslucentHands` 的判等就反过来 ——
+solid pass 被 cancel、translucent pass 得以提交，
+于是整把枪走 `gbuffers_hand_water`，**跑在 `beginTranslucents()` 之后**，
+`colortex0` 这时才真的装着已着色的场景，模式 3 的采样就成立了。
+
+改动量极小（远小于「自己在半透明边界画一遍目镜网格」那条路 ——
+那条要自建顶点格式、还要跟 pack 的 vsh 对 MVP，盲改风险太高）。
+
+**已落地的五处**：
+
+| # | 文件 | 改动 |
+|---|---|---|
+| 1 | `mixin/client/iris/IrisHandTranslucentMixin.java`（新） | `HandRenderer#isHandTranslucent` HEAD 注入：持枪且 `wantsIrisComposite()` 时返回 true |
+| 2 | `tacz.iris.mixins.json` | 注册上面这个 mixin |
+| 3 | `compat/iris/IrisCompat.java` | 新增 `isHandRenderingSolid()`，**Method 句柄惰性解析并缓存**（逐 draw 调用，不能每次反射查表） |
+| 4 | `compat/iris/IrisScopeMaskState.java` | 镜身通道：`wantsIrisComposite() && !isHandRenderingSolid() ? 3 : 1` |
+| 5 | `client/render/scope/ScopePipRenderer.java` | 新增 `irisOwnsLens()`；光影下 `captureScene` / `compositeAtPhaseBoundary` 整条让开 |
+
+着色器侧**没动**：模式 3 的分支早就写好，且黑八边形那次已证明它能把颜色写到屏幕上。
+
+#### 两个必须知道的坑（都已处理）
+
+**(a) 逐帧 latch —— 不做的话枪会整把消失。**
+`isHandTranslucent` 一帧被问<b>两次</b>（实心一次、半透明一次），
+而 Iris 的判据是 `isRenderingSolid() == isHandTranslucent(stack) → cancel`。
+两次答案必须一致：
+- 都答 true：实心 `true==true` cancel（让位），半透明 `false==true` 不成立 → 提交 ✔
+- 若半透明那次答成 false：`false==false` → **也 cancel** ⇒ 两遍都没画，**枪没了**。
+
+而现算的输入里确实有帧内会漂的量（开镜进度按 partialTick、掩码标志由渲染过程置位）。
+所以 `ScopePipBridge.wantsIrisComposite()` 改成**本帧第一次问就定下答案并缓存**，
+由 `ScopePipBridge.beginFrame()`（挂在 `GameRenderer#extract` HEAD）每帧清空。
+
+**(b) 镜片只能有一个主人。**
+光影下若让「拷贝主画面 + 全屏重投影」那条老路继续跑，它会用 vanilla 管线把一张
+**未经光影着色**的图糊进孔径，正好盖掉 shader 注入刚写对的颜色。
+`irisOwnsLens()` 把它整条关掉，顺带省一次每帧全屏拷贝。
+
+#### 实测时照这三行日志走（按出现顺序）
+
+```
+[TACZ Scope] Routing the scoped gun into Iris' translucent hand pass ...
+[TACZ Scope] Iris scope-mask bridge active (mode=..., ...)
+[TACZ Scope] Scope PIP is drawing in the Iris translucent hand pass (post-deferred); ... zoom=Nx
+```
+
+- 第 1 行没出现 ⇒ `IrisHandTranslucentMixin` 没生效（`require = 0`，**失败是静默的**）。
+  查 Iris 版本是否改了 `isHandTranslucent` 的名字/签名。
+- 第 1 行有、第 3 行没有 ⇒ 枪挪过去了但镜身没解析到模式 3，
+  查 `isHandRenderingSolid()` 的反射是否解析成功（解析失败会保守返回 true）。
+
+### 2.3d 【已废弃 · 保留为路标】镜内「灰噪块 + 黑」：场景色不在 colortex0
+
+挪进半透明 pass 之后镜片不再是纯黑，但内容不对：
+上部是天空、左下一块灰噪矩形、右下纯黑。
+
+**真因**：写死了 `colortex0`，而那一刻 colortex0 装的是 **gbuffer 数据**，不是着色后的场景。
+各家 pack 把场景色放哪张是自己定的，用 `/* RENDERTARGETS:a,b,c */` 声明，
+**第一个索引**就是该程序 location 0 的输出 —— 对半透明程序而言正是「要混进去的那张场景色」。
+
+逐文件实读用户的 Eclipse-Shader-Unstable（只读解包，未改动 zip）：
+
+| 文件 | 指令 | 说明 |
+|---|---|---|
+| `world0/gbuffers_hand_water.fsh` | → `#include /dimensions/all_translucent.fsh` | 镜片就跑在这个程序里 |
+| `dimensions/all_translucent.fsh` | `RENDERTARGETS:2,7,11,14` | **location 0 → colortex2** |
+| `dimensions/deferred2.fsh` | `RENDERTARGETS:2,1,9` + `gl_FragData[0] = texelFetch(colortex2, …)` | 场景色确实是 colortex2 |
+
+⇒ 该 pack 的**场景色 = colortex2**。
+
+**顺带解决了「会不会读写同一张纹理」那个悬念**（原 §2.3c 待确认项 2）：
+`deferred2` 自己就同时读写 colortex2 且工作正常，
+**证明 Iris 对它做了乒乓翻转** —— 我们在同一程序里读它拿到的是「本 pass 之前」的内容，
+正是想要的已着色场景，不是未定义行为。
+
+**当时的修法**（现已连同整条路一起删除）：新增配置 `ScopePipShaderSceneTex`（默认 `-1` = 自动）。
+自动 = 从源码里解析 `RENDERTARGETS`/`DRAWBUFFERS` 取第一个索引，解析不到退回 0
+（与 Iris 自己对无指令 pack 的默认一致）。
+
+> ⚠️ **自动判定可能失灵**：该指令是 pack 加载期由 `ProgramDirectives` 解析的，
+> 而我们拿到的是 glsl-transformer **变换后**的源码，注释很可能已被剥掉。
+> **所以先看日志那一行**：
+> `Injecting scope-mask branch into Iris linked fragment shaders (scene tex: colortexN, …)`
+> 若 N 不是期望值，就用配置显式指定。**Eclipse-Shader-Unstable 应设为 2。**
+> 改完要重载 shaderpack（R）。
+
+#### 仍待实测确认的一件事
+
+1. **观感**：枪整体改走 `gbuffers_hand_water`，不再参与延迟光照，
+   着色可能与实心通道略有差异。只在「持倍镜 + 开镜」那几帧发生。
+   若不可接受，退路是加一个配置项把 (1) 关掉 —— 届时镜片自动退回透视 1×。
+
+> 原来的待确认项 2（读写同一张纹理是否会炸）已由 §2.3d 解决：
+> `deferred2` 自己就同时读写 colortex2，证明 Iris 会翻转，不是未定义行为。
+
+### 2.4 已经排除的（别再试一遍）
+
+| 尝试 | 结果 |
+|---|---|
+| 读当前绑定 FBO 的 `COLOR_ATTACHMENT0` | 读到法线缓冲（实测：镜内是放大的法线+营火） |
+| 写当前绑定 FBO | **写是成功的**（画面能到屏幕），但那是 gbuffer，不是场景 |
+| 反射 `RenderTargets.get(n).getMainTexture()` | 平铺 8 格**全空** |
+| 同上但取 `getAltTexture()` | 同样**全空** ⇒ 这条反射取法本身不可信 |
+| `getFlippedAfterPrepare/AfterTranslucent()` | 报「未翻面」，与实测不符，别拿它当准 |
+| 自建 FBO 挂 colortex0 去写 | 写进去的内容被下游丢弃，屏幕无变化 |
+| 二次渲染（rerender）在光影下 | **禁用**：一帧两次驱动 Iris 管线会把它的时域/乒乓缓冲搞乱，整屏噪点。已在 `rerenderMode()` 里硬性拦下 |
+
+### 2.5 【已推翻】曾把 Voxy 的 viewport 归因于 `IrisScopePip`
+
+当时写的是：「`IrisScopePip.drawColortexGrid()` 逐格设 `glViewport(...)` 而
+`restoreGlState()` 没还原，Voxy 读到残留视口」。
+
+**这条是错的**，2026-08-21 的日志逐条推翻了它：
+
+- 08-21-**2** 会话：光影已加载（6 条 `Found fine program match`），Voxy 报错 **0 次**；
+- 08-21-**7** 会话（03:41，跑的正是含 `IrisScopePip` 的 03:37 jar）：**47366 次**；
+- 08-21-**8** 会话（04:05，跑的是已删除 `IrisScopePip` 的 03:44 jar）：**仍有 4074 次**。
+
+删掉 `IrisScopePip` 前后症状一模一样 ⇒ 它从来就不是原因。
+`IrisScopePip` 与 `IrisBeginHandMixin` 的删除本身无害（§2.4 已证伪那条路），但**没修任何东西**。
+
+真凶见 §2.6。
+
+> **方法论**：这是本项目第 9 次「有理有据但错误」的归因，模式与前 8 次完全一致 ——
+> 症状对上就下结论。真正定位它的动作只有一个：**把报错次数按会话拉成一张表**，
+> 让「删除前/删除后」自己说话。
+
+### 2.6 【真凶 · 已修】`colortex1` 前缀撞名 → 光影被整体禁用 → Voxy 陪葬
+
+**因果链**（全部来自 08-21 的日志，非推导）：
+
+1. `IrisShaderCreatorMixin` 用 `source.contains("colortex" + i)` 判断 pack 是否已声明该采样器；
+2. Eclipse-Shader-Unstable 的 `dimensions/all_translucent.fsh` 声明了
+   `colortex11`/`12`/`13`/`14`，**没有 `colortex1`**。
+   `"colortex11".contains("colortex1")` 为真 ⇒ 我们**跳过**了 `colortex1` 的补声明；
+3. 而探针网格**无条件**引用 `colortex0..7`（GLSL 两个分支都要编译，运行期闸门救不了）；
+4. `terrain_translucent: error C1503: undefined variable "colortex1"`；
+5. Iris：`Failed to create shader rendering pipeline, disabling shaders!`；
+6. Iris 管线没建起来 ⇒ Voxy 的 `CAPTURED_VIEWPORT_PARAMETERS` 从没被 apply ⇒
+   `Viewport` 恒为 0×0 ⇒ `renderOpaque` 每帧打
+   `Viewport width or height was zero, this is bad bad bad, exiting frame`。
+
+**判据（值得记住的取证手法）**：`VoxyRenderSystem` 里那句话有**两个**调用点，
+文案差一个后缀。日志里 `exiting frame` 变体 4074 次、`setupViewport` 变体 **0 次** ——
+「从没被建立」而不是「被建立成了 0」，一眼就把 Voxy 摘成了下游受害者。
+
+**修法**（两处，均在 `IrisShaderCreatorMixin`）：
+
+1. 判定改成整词匹配 `\bcolortexN\b`，`colortex11` 不再冒充 `colortex1`；
+2. 探针网格改成**链接期**生成。关着时只声明并引用 `colortex0`，
+   炸包面缩到最小；开着时才声明 `colortex0..7`。
+
+`./gradlew build` 通过（04:1x）。
+
+> 光影路径现在**只剩 shader 注入**一条，不含任何裸 GL 状态改动。
+
+---
+
+## 2.7 镜内清晰度：上限在哪、能怎么提
+
+### 2.7.1 硬上限（先认清这条，再谈优化）
+
+镜内画面是主画面中心那一块放大来的，所以
+
+```
+镜内可用的真实像素 = 屏幕像素 ÷ 镜内放大倍数
+```
+
+8 倍镜就是只有 1/8 的像素铺满整个镜片。这是**信息量**上限，不是算法问题 ——
+锐化、双三次重建都只能改善<b>主观</b>锐度，**变不出真实细节**。
+（当前已实装：Catmull-Rom 双三次重建 + 按倍率加权的钝化蒙版，基本到顶了。）
+
+### 2.7.2 真正能增加像素的三条路
+
+| 办法 | 镜内像素 | 代价 | 状态 |
+|---|---|---|---|
+| **① 二次渲染**（`ScopePipRerender=true`） | **原生，无上限** | 每帧多跑一遍世界渲染 | ✅ 无光影下可用；**光影下被硬性拦下**（一帧两次驱动 Iris 会搞乱它的时域/乒乓缓冲，整屏噪点） |
+| **② 倍率拆分**（`ScopePipWorldZoomShare`，本轮新增） | **×Z^share** | 镜外也放大 Z^share 倍 | ✅ 两条路都可用 |
+| **③ 提高整体渲染分辨率** | 按比例 | 全局性能 | 玩家侧的事（更高显示分辨率／渲染缩放类 mod），本 mod 不介入 |
+
+### 2.7.3 倍率拆分怎么算的
+
+倍率是**相乘**的，所以按指数分配：
+
+```
+世界 W = Z^share      镜内 P = Z^(1-share)      W × P ≡ Z（恒等，与 share 无关）
+```
+
+镜内只需放大 `P`，于是它能用的真实像素**多 W 倍**。
+
+| share | 世界 W | 镜内 P | 镜内真实像素 | 说明 |
+|---|---|---|---|---|
+| `0.0` | 1.00 | Z | ×1 | 纯 PIP，镜外 1×（最软） |
+| `0.5` | √Z | √Z | ×√Z | 对半分 |
+| `1.0` | Z | 1.00 | ×Z | 整屏变焦（最锐，等于关掉 PIP） |
+
+以 8× 镜为例：`share=0.5` → 世界 2.83×、镜内 2.83×，镜内真实像素是纯 PIP 的 **2.83 倍**。
+
+**默认 `0.0` 与改动前逐位等价**：`W=1` ⇒ `magnificationToFov(1, fov) == fov`，
+合成侧 `Z/1 == Z`，两边都不变。
+
+> ### ⚠️ 第一版用的是「绝对上限」`ScopePipMaxWorldZoom`，已废弃 —— 别再改回去
+>
+> 那个设计有个致命缺陷：`W` 必须被 `Z` 夹住（世界放大不能超过总倍率），
+> 于是**任何 ≥ Z 的取值都得到 `W = Z` ⇒ 镜内倍率 `Z/W = 1` ⇒ 镜内彻底不放大**，
+> PIP 名存实亡。而那个临界点<b>就是瞄具倍率本身</b>，换把枪就换个位置。
+>
+> 玩家实测直接撞上：「超过 3.0 就没有放大了」—— 那把镜正好 3×，
+> 而配置上限是 8.0，也就是 3.0~8.0 整段是行为相同、且功能已被关掉的**死区**。
+>
+> 按比例分配没有这个问题：`[0,1]` 上每一点都有意义、都不同，
+> 且**与瞄具倍率无关**（2× 镜和 8× 镜上同一个 share 表现一致）。
+
+实装要点（改这块必须两边同时改，否则镜内外放大程度会打架）：
+
+- `CameraSetupEvent`：PIP 生效时不再「完全不动 FOV」，而是按 `1+(W-1)·progress` 放大；
+- `ScopePipRenderer`：两个 `runComposite(...)` 调用点都**除掉**世界已放大的那一份。
+  两者相乘恒等于总倍率，这是这套拆分的不变式。
+- **二次渲染模式下 `worldZoomTarget()` 恒返回 1** —— 那条路镜内本来就是原生像素，
+  放大世界只会白白牺牲镜外画质、换不到任何东西。
+
+### 2.7.4 给玩家的建议
+
+- **无光影**：开 `ScopePipRerender=true`，镜内原生分辨率，不需要动 ②。
+- **开光影**：只能走屏幕空间那条，高倍镜偏软是必然的。
+  嫌软就把 `ScopePipWorldZoomShare` 调到 `0.3`～`0.5`（镜内真实像素约 ×1.5～×2.8）；
+  完全不在意镜外跟着放大就调 `1.0`，那等于回到整屏变焦（最清晰，但没有 PIP 效果）。
+
+---
+
+## 3. 配置键（全部在 `config/tacz-client.toml` 的 `[render]` 下）
+
+| 键 | 默认 | 说明 |
+|---|---|---|
+| `ScopePipEnable` | `false` | PIP 总开关 |
+| `ScopePipRerender` | `false` | 二次渲染（原生分辨率）。光影下自动忽略 |
+| `ScopePipAllowShaderPacks` | `false` | 允许光影下跑 PIP（目前不出图，见 §2） |
+| `ScopePipSharpness` | `0.5` | 重投影模式的锐化上限（只提升主观锐度） |
+| `ScopePipWorldZoomShare` | `0.0` | 瞄具倍率里由**世界**承担的比例，用来换镜内真实分辨率。见 §2.7。`0.0` = 与改动前逐位等价；`1.0` = 等于关掉 PIP |
+| `ScopePipMinAimingProgress` | `0.05` | 低于此开镜进度不做 PIP |
+| `ScopePipDebugPaintLens` | `false` | 诊断：把合成实际覆盖到的区域涂成纯品红（整屏变色 = 合成没被掩码约束住） |
+| `ScopePipDebugNoComposite` | `false` | 诊断：跑 PIP 但不合成 |
+| `ScopePipDebugTrace` | `false` | 诊断：打印渲染目标解析顺序（只记跑过 PIP 的帧） |
+
+**推荐给玩家的组合**：`ScopePipEnable=true`、`ScopePipRerender=true`、其余默认。
+
+---
+
+## 4. 下一步（按优先级）
+
+0. **先确认光影没被我们弄挂**（§2.6 修完后的第一件事）：日志里**不应**再出现
+   `undefined variable "colortex1"` 或 `disabling shaders!`，且**应当**出现
+   `Found fine program match for tacz:pipeline/...`。Voxy 的刷屏会随之自己消失。
+1. **跑 §2.3 的孔径网格探针**：`ScopePipEnable/AllowShaderPacks/DebugPaintLens` 全开，
+   **改完配置要重载 shaderpack（R 键）**，日志确认 `colortex probe grid: ON`，
+   用 **3.25× 或 4.25× 的真倍镜**（红点/全息走 sight 通道，不产掩码，恒不出 PIP），
+   截图看哪一格有画面 → 那就是要在模式 3 里采样的 colortex。
+2. 把模式 3 的采样源换成第 1 步找到的那张，验证放大是否出现。
+3. 若出现但颜色不对：手部输出会被 pack 再光照一次，需要补偿
+   （已着色的值当成 albedo 再打光）。属可控的小问题。
+4. `tacz$findFragmentOutput` 目前认三种写法（`layout(location=0) out vec4`、
+   裸 `out vec4`、`gl_FragData[0]`）。**认不出就整段不注入** —— 宁可没功能，
+   也不能塞进编译不过的代码把整个 shaderpack 弄挂。换 pack 测试时留意这条。
+
+---
+
+## 5. 工作方式上的教训（这条比代码值钱）
+
+整晚**至少 8 次**「有理有据但错误」的归因。共同模式：
+**拿到一个事实 → 修那个事实 → 后面又冒出一个新事实**。
+真正推动进展的只有两类动作：
+
+1. **读实际字节码**（Sodium / Iris / Voxy 的 jar，只读解包到临时目录）；
+2. **加诊断把猜测变成读数** —— 帧序 trace、`gate ->` 闸门日志、涂色探针、孔径网格。
+
+反过来，纯靠「症状像什么」的推断**命中率接近零**。
+另外有一次诊断日志本身把病症整形成了正常样（两秒限流把逐帧抖动打成整齐间隔），
+**诊断日志的形状会骗人，限流要小心**。
+
+### 环境上的坑
+- 用户 `mods/` 里曾同时存在 R1 与 R2 两个 TaCZ jar，Fabric 选了 **R1**，
+  导致「改了没反应」且配置被旧 spec 重写、PIP 键全丢。
+  **每次实测前先确认日志里 `- tacz 1.1.8+fabric.26.2.R2`。**
+- 用户实例：Sodium 0.9.1 + Iris 1.11.2 + Voxy 0.2.18 + ImmediatelyFast + Physics Mod。
+  任何「所有绘制都经过某个原版方法」的假设都要先对这几个验证。
+
+---
+
+## 6. 约束（用户明确要求）
+
+- **只允许改本仓库的文件。** 其他 mod 的 jar、shaderpack 的 zip、
+  `.minecraft` 下的任何东西**一律不得写入**。
+- 运行时反射/改内存状态是**允许**的（`SodiumCompat` 就是这么干的）；
+  改磁盘上的字节**不允许**。
+- shader 注入是**内存内**改字符串，pack 的 zip 从未被打开写入 —— 符合上述约束。

--- a/docs/SCOPE_PIP_HANDOFF_2026_08_21.md
+++ b/docs/SCOPE_PIP_HANDOFF_2026_08_21.md
@@ -464,6 +464,58 @@ solid pass 被 cancel、translucent pass 得以提交，
 
 ---
 
+## 2.8 开镜晃动强度（`AimingSwayIntensity`）
+
+### 2.8.1 晃动是什么
+
+不是新加的效果，而是本来就有的「枪跟不上视角转动」的滞后量：
+
+```java
+xRot = player.getViewXRot(partialTick) - lerp(partialTick, player.xBobO, player.xBob);
+```
+
+`getViewXRot` 是当前朝向，`xBob/yBob` 是 vanilla 维护的平滑滞后值，两者之差就是
+「刚才甩了多少」。这个差值驱动 6 个分量：整模型 pitch/yaw 反向旋转各一、
+`rootNode` 的 X/Y 偏移各一、`additionalQuaternion` 的 pitch/yaw 各一。
+
+### 2.8.2 为什么要给开镜单独加一档
+
+原实现对腰射与开镜**一视同仁**。但开镜后视野被瞄具收窄，PIP 更是把镜内又放大了 Z 倍
+—— 同样的角度抖动在镜内被放大成同样倍数的位移。现实里高倍镜正是「越放大越难稳住」，
+而原来的镜内反而显得过于稳定。
+
+按开镜进度插值（**不是**开镜就切换）：`scale = lerp(aimingProgress, 1.0, intensity)`。
+用插值是为了避免抬镜那一瞬幅度突然跳一下 —— 那种跳变比晃动本身更容易被察觉。
+
+| intensity | 腰射 | 满开镜 | 满开镜时最大旋转 / 位移 |
+|---|---|---|---|
+| `0.0` | ×1 | ×0 | 0.00° / 0.0000 |
+| `1.0` | ×1 | ×1 | 1.25° / 0.0521（**与改动前逐位一致**） |
+| `1.5`（默认） | ×1 | ×1.5 | 1.88° / 0.0781 |
+| `3.0` | ×1 | ×3 | 3.75° / 0.1563 |
+
+**腰射手感在任何取值下都不变** —— 进度 0 时插值恒为 1。
+
+### 2.8.3 两处必须同时改
+
+同一套公式在代码里有**两份拷贝**：
+
+| 文件 | 说明 |
+|---|---|
+| `client/renderer/item/GunItemRendererWrapper.java` | **枪械实际走的那一份** |
+| `client/renderer/item/AnimateGeoItemRenderer.java` | 父类的通用实现 |
+
+只改一处的表现是「有的枪改了有的没改」，极难定位。
+缩放系数统一由父类的 `aimingSwayScale()` 提供，避免两边算法漂移。
+
+> `tanh` 饱和限幅保持在缩放**之前**：它防的是快速转身时枪飞出画面，
+> 那道保护必须先生效，缩放只放大限幅后的结果。上表的「最大位移」列就是限幅后的上界。
+
+> lrtactical 的近战 / 投掷物渲染器里也有同样的 sway 公式，但**刻意不动** ——
+> 它们没有瞄具，开镜进度对它们没有意义。
+
+---
+
 ## 3. 配置键（全部在 `config/tacz-client.toml` 的 `[render]` 下）
 
 | 键 | 默认 | 说明 |
@@ -473,6 +525,7 @@ solid pass 被 cancel、translucent pass 得以提交，
 | `ScopePipAllowShaderPacks` | `false` | 允许光影下跑 PIP（目前不出图，见 §2） |
 | `ScopePipSharpness` | `0.5` | 重投影模式的锐化上限（只提升主观锐度） |
 | `ScopePipWorldZoomShare` | `0.0` | 瞄具倍率里由**世界**承担的比例，用来换镜内真实分辨率。见 §2.7。`0.0` = 与改动前逐位等价；`1.0` = 等于关掉 PIP |
+| `AimingSwayIntensity` | `1.5` | 开镜时持枪晃动的强度倍数。见 §2.8。腰射永不受影响；`1.0` = 与改动前逐位一致；`0.0` = 满开镜完全不晃 |
 | `ScopePipMinAimingProgress` | `0.05` | 低于此开镜进度不做 PIP |
 | `ScopePipDebugPaintLens` | `false` | 诊断：把合成实际覆盖到的区域涂成纯品红（整屏变色 = 合成没被掩码约束住） |
 | `ScopePipDebugNoComposite` | `false` | 诊断：跑 PIP 但不合成 |

--- a/docs/SCOPE_PIP_HANDOFF_2026_08_21.md
+++ b/docs/SCOPE_PIP_HANDOFF_2026_08_21.md
@@ -516,6 +516,70 @@ xRot = player.getViewXRot(partialTick) - lerp(partialTick, player.xBobO, player.
 
 ---
 
+## 2.9 【08:2x 已修】`ScopePipDebugTrace` 会把显存撑爆 —— 一个诊断开关引发的崩溃
+
+### 2.9.1 症状
+
+四处跑图约 90 秒后崩溃：
+
+```
+com.mojang.blaze3d.GpuOutOfMemoryException: Could not allocate buffer of 88106400
+    at ...sodium...GlBufferArena.resize(GlBufferArena.java:66)
+    at ...RenderSectionManager.processChunkBuildResults(...)
+```
+
+**在静止的小测试区完全不复现** —— 只有真正跑图时才炸。
+（也正因如此一开始被误判成「显存泄漏」，查了半天分配点，其实一处都没漏。）
+
+### 2.9.2 真因：预算永远扣不掉，诊断整局常驻
+
+`ScopePipTrace` 本来设计成「只采 3 帧就收摊」：
+
+```java
+enabled()  =  配置为真  &&  framesTraced < FRAME_BUDGET
+framesTraced++ 只发生在 sawScopePass 为真的帧
+sawScopePass 只由 mark("SCOPE-PASS BEGIN") 置位
+mark("SCOPE-PASS BEGIN") 只在 renderScopeView（二次渲染）里发出
+```
+
+而**二次渲染在光影下是被硬性拦下的**（§2.4）。于是：
+
+> 光影下 `sawScopePass` 永远为 false ⇒ `framesTraced` 永远是 0 ⇒
+> `enabled()` 永远为真 ⇒ **整局游戏每帧都在武装状态**。
+
+代价是每帧最多 400 次 `StackWalker.walk()`，而它挂在 `mainRenderTarget()` 上 ——
+Sodium 地形、Voxy、帧图导入全都要调这个方法。
+
+### 2.9.3 从「渲染线程慢」到「显存爆掉」的那一步
+
+这一步是本案最不直观的地方，值得记住：
+
+1. 渲染线程被 StackWalker 拖垮；
+2. 区块构建在**工作线程**上照常进行，不受影响 —— 于是构建结果越堆越多；
+3. 渲染线程终于轮到 `processChunkBuildResults` 时，要**一次性**上传巨量结果；
+4. Sodium 的 `GlBufferArena.resize` 于是要一口气申请 88 MB，
+   而扩容期间**新旧缓冲并存**（≈2 倍）；
+5. 显存给不出 ⇒ `GpuOutOfMemoryException`。
+
+所以「跑图才炸」是必然的：**只有跑图才有大量区块构建**。
+静止时构建队列是空的，渲染线程再慢也堆不出东西来。
+
+### 2.9.4 修法（两条，缺一不可）
+
+1. **绝对上限** `ARMED_FRAME_LIMIT = 600`：无论有没有采到样本，
+   武装满 600 帧就永久收摊并打一行说明。
+   计数在 `beginFrame()` 里**无条件**累加 —— 只要这一帧武装了就算数。
+2. **让光影那条路也能扣预算**：`compositeAfterLevelUnderShaders()` 发出
+   `PIP COMPOSITE`，`mark()` 认它与 `SCOPE-PASS BEGIN` 等价。
+
+> ### 教训（比这个 bug 本身值钱）
+>
+> **诊断开关的收摊条件，绝不能依赖「被诊断的那条路」自己发信号。**
+> 那条路不跑，恰恰是你要诊断的情形 —— 于是最需要它收摊的时候它永不收摊。
+> 任何自限诊断都必须带一个**与业务逻辑完全无关**的绝对上限。
+
+---
+
 ## 3. 配置键（全部在 `config/tacz-client.toml` 的 `[render]` 下）
 
 | 键 | 默认 | 说明 |
@@ -529,7 +593,7 @@ xRot = player.getViewXRot(partialTick) - lerp(partialTick, player.xBobO, player.
 | `ScopePipMinAimingProgress` | `0.05` | 低于此开镜进度不做 PIP |
 | `ScopePipDebugPaintLens` | `false` | 诊断：把合成实际覆盖到的区域涂成纯品红（整屏变色 = 合成没被掩码约束住） |
 | `ScopePipDebugNoComposite` | `false` | 诊断：跑 PIP 但不合成 |
-| `ScopePipDebugTrace` | `false` | 诊断：打印渲染目标解析顺序（只记跑过 PIP 的帧） |
+| `ScopePipDebugTrace` | `false` | 诊断：打印渲染目标解析顺序。**开销极大**，正常游玩务必保持关闭，见 §2.9 |
 
 **推荐给玩家的组合**：`ScopePipEnable=true`、`ScopePipRerender=true`、其余默认。
 

--- a/docs/SCOPE_PIP_IMPLEMENTATION_2026_08_19.md
+++ b/docs/SCOPE_PIP_IMPLEMENTATION_2026_08_19.md
@@ -1,0 +1,308 @@
+# 瞄准镜镜内画中画（Scope PIP）· 实现记录
+
+> **⚠️ 本文是 08-19 当天的阶段记录，部分结论已被后续实测推翻。**
+> **当前状态与接续工作请先读 [`SCOPE_PIP_HANDOFF_2026_08_21.md`](SCOPE_PIP_HANDOFF_2026_08_21.md)。**
+> 尤其：本文 §3 关于「镜内分辨率上限」的讨论只适用于重投影模式；
+> 二次渲染模式已实装并可用，且当晚被当作「溢出」追查了很久的现象，
+> 真因是 Sodium 的 `hasUpdatedThisFrame` 每帧单次上传闸，与溢出无关。
+
+**日期**：2026-08-19
+**分支**：`26.2(main)`
+**状态**：**代码完成、`./gradlew build` 通过；第二版尚未实机验证**
+**开关**：`ScopePipEnable`，**默认关闭**
+
+> ⚠️ 按 `AGENTS.md` §2：本文区分「已实测」与「静态推导」。
+> §1 的失败结论是**用户实机观察到的**；§2 之后的新方案是静态推导 + 编译通过，
+> **尚未实机验证**。
+
+---
+
+## 0. 目标
+
+| | FOV 整屏变焦（改动前，默认） | PIP（本次新增，默认关） |
+|---|---|---|
+| 镜内 | 放大 | 放大 |
+| **镜外（镜筒周围的画面）** | **也跟着放大** | **保持 1×** |
+| 上游 1.21.1 有没有 | 有 | 没有 |
+
+「镜外不该跟着放大」是 FOV 方案在物理上做不到的事 —— 它只有一个摄像机 FOV。
+
+---
+
+## 1. 【已作废】第一版：重定向 target + 再渲染一遍世界
+
+方案：把 `GameRenderer#mainRenderTarget()` 临时重定向到离屏 target，
+用窄 FOV 再跑一次 `LevelRenderer#render`。即 `SCOPE_PIP_PLAN.md` §8.3 的方案 A。
+
+**实机结果：失败。** 用户环境 Sodium 0.9.1 + ImmediatelyFast + Iris 1.11.2（无光影包）。
+
+### 1.1 【已更正】首次归因是错的
+
+失败当天我给出的根因是「Sodium 完全接管地形渲染、不走 `mainRenderTarget()`，
+所以重定向对它无效」。**那是错的。** 事后逐条反编译 Sodium 0.9.1 查清了真正的机理：
+
+| 症状 | **真正的**根因 |
+|---|---|
+| 镜内「部分物件放大、大部分方块没放大，画面糊在一起」 | **投影矩阵，不是渲染目标。** Sodium 的地形输出<b>确实</b>调用 `GameRenderer#mainRenderTarget()`（`TerrainRenderPass` 字节码实读），重定向对它是有效的。但它的投影用的是自己快照的那一份 —— `GameRendererStorage.sodium$getProjectionMatrix()`，由 Sodium 的 `GameRendererMixin` 用 `WrapOperation` 包住 `renderLevel` 里的 `ProjectionMatrixBuffer#getBuffer(Matrix4f)` 抓取。第一版只改了 `RenderSystem.setProjectionMatrix`，Sodium 压根不看那个 ⇒ 地形用宽 FOV、原版路径的实体用窄 FOV，两套比例叠在一起 |
+| **镜外**的实体与部分物件整个消失 | 一帧内两次驱动 `LevelRenderer#render`，打乱了 Sodium 与 ImmediatelyFast 的逐帧状态。**这一条至今未查清** |
+
+### 1.2 该记住的教训（两条）
+
+1. `SCOPE_PIP_PLAN.md` §8.3 那套推导逐条核对的是**原版**字节码，在原版渲染下成立。
+   错在没有把「玩家实际会装 Sodium」当作前提去检验。本仓库的目标受众几乎必然使用
+   Sodium，任何依赖「所有绘制都经过某个原版方法」的方案都要先问：**Sodium 还走那条路吗？**
+2. 更要紧的一条：**症状对上了不等于归因对了。** 「地形没放大」既可以由
+   「渲染目标没跟随」解释，也可以由「投影矩阵没跟随」解释，两者在画面上完全一样。
+   当时选了前者且没有验证，直接据此推翻了整条技术路线。
+   正确的做法是**先读 Sodium 的字节码再下结论** —— 那只花了十几分钟。
+
+### 1.3 这条路还有没有救
+
+有，但没走通：
+- 投影矩阵问题**可解** —— Sodium 的快照挂在 `GameRenderer` 实例上，可以同步改写；
+- 逐帧状态问题**未解**（§1.1 第二行），且需要在体反复试错。
+
+所以第一版代码整体删除；若将来要追求高倍清晰度，必须从这两条重新开始。
+
+---
+
+## 2. 第二版（当前）：屏幕空间重投影
+
+### 2.1 核心恒等式
+
+透视投影下，「把 FOV 压窄 Z 倍」在屏幕空间**恒等于**「绕光轴把画面放大 Z 倍」：
+
+```
+窄FOV下某点的 NDC = 宽FOV下同一点的 NDC × Z          （Z = 倍率）
+  ⇒ 反过来采样： wideUV = center + (narrowUV − center) / Z
+```
+
+推导：视线偏离光轴 θ 的点，宽 FOV 下 NDC ∝ `tan θ / tan(fov_w/2)`，
+窄 FOV 下 NDC ∝ `tan θ / tan(fov_n/2)`，比值 = `tan(fov_w/2)/tan(fov_n/2)` = Z
+（这正是 `MathUtil.magnificationToFov` 的定义）。
+
+**这不是近似。** 相机位置与朝向都没变，只有 FOV 变了，所以「重渲一遍」与
+「重采样一遍」逐像素等价，差别只在分辨率。
+
+于是根本不需要再渲染世界：把已经画好的世界拷出来、按上式重采样即可。
+`|uv − center| ≤ 0.5` 且 `Z ≥ 1`，采样点必然落在 `[0,1]` 内，连边界钳制都不需要。
+
+### 2.2 每帧流程
+
+```
+GameRenderer#renderLevel
+ ├─ levelRenderer.render(...)               ← vanilla（或 Sodium）照常画，FOV 未被瞄具修改
+ │
+ ├─【注入 AFTER】ScopePipRenderer.captureScene
+ │     └─ copyTextureToTexture(主target色纹理 → 离屏拷贝)     ← 唯一的额外 GPU 工作
+ │
+ ├─ 清主 target 深度
+ └─ renderItemInHand
+      └─ renderAllFeatures
+           ├─【阶段边界】ScopeMaskRenderer.renderAtPhaseBoundary()   目镜掩码
+           ├─【阶段边界】ScopePipRenderer.compositeAtPhaseBoundary()
+           │      全屏三角形：掩码内的像素 ← 拷贝在 center+(uv-center)/Z 处的颜色
+           └─ executeSolid / executeTranslucent …
+                 镜身 → 掩码内 discard（PIP 画面留住）
+                 准星 → 反向裁剪只画掩码内（浮在 PIP 画面之上）
+```
+
+### 2.3 拷贝时机是一个很窄的窗口
+
+必须夹在 `LevelRenderer#render` **之后**、`renderItemInHand` **之前**：
+
+- 再早 → 世界还没画完；
+- 再晚 → 拷贝里混进枪和手，镜片里会出现一把缩小的枪。
+
+renderLevel 偏移 405 之后、502 之前正是这个唯一窗口。
+该位置不在任何 render pass 内（vanilla 紧接着就调 `clearDepthTexture`，
+那个方法有同样的约束，等于替我们证明了）。
+
+### 2.4 为什么要拷贝，不能直接采样主 target
+
+合成那一趟是往主 target **写**。若同时又从主 target **读**，
+就是在同一个 render pass 里对同一张纹理又读又写 —— 未定义行为。
+拷贝那一步存在的全部意义就在这里。
+
+一次全屏 `copyTextureToTexture` 的开销与「多渲一遍世界」不在一个量级。
+两张纹理都由 `RenderTarget#createBuffers` 建，usage 位是
+`bipush 15` = `COPY_DST|COPY_SRC|TEXTURE_BINDING|RENDER_ATTACHMENT`（字节码实读），
+拷贝需要的两个位都在。目标纹理的格式取自源纹理本身，保证两端一致。
+
+### 2.5 倍率怎么送进着色器
+
+借 `DynamicTransforms` 的 `ColorModulator.r`。`bindDefaultUniforms` 只管
+Projection / Fog / Globals / Lighting 四个块，`DynamicTransforms` 得自己
+`setUniform` —— 与 `ScopeMaskRenderer` 同一套路。
+
+管线在 `POST_PROCESSING_SNIPPET`（= public 的 `builder(GLOBALS_SNIPPET)` +
+TRIANGLES，偏移 1120-1142 实读）之上加三个 layout：
+`IN_SAMPLER` + 自建掩码采样器 + `DYNAMIC_TRANSFORMS`。
+
+### 2.6 孔径判定与 `scope_body.fsh` 共用同一份逻辑
+
+`assets/tacz/shaders/core/scope_pip.fsh` 里的 `insideOcular` 判定
+（含按开镜进度沿掩码边缘向内收缩那一段）是从 `scope_body.fsh` **原样搬来的**。
+一个在孔径内 `discard` 让路、一个在孔径内落笔，判定只要错开一点点，
+边缘就会出现「既没被镜身画、也没被 PIP 贴」的裂缝。
+
+**改其中一个文件时必须同时改另一个。** 两处注释都写了这句。
+
+---
+
+## 3. 代价：高倍镜下镜内会变软
+
+### 3.1 放大倍数就是瞄具倍率（初稿把这条算错了，已更正）
+
+初稿写的是「设镜片直径约占屏高的 0.4，实际放大 ≈ `0.4 × Z`」。**那是错的**，
+它把「镜片在屏幕上多大」与「镜片里的内容被放大了多少」混为一谈。
+
+正确的推导：合成是对**整屏**做重投影，镜片只是这张重投影图上的一个**窗口**。
+屏幕上直径 D 的镜片，其像素映射回原画面只覆盖 `D / Z` 个像素，
+却要铺满 D 个像素 ⇒ **放大倍数恒等于 Z**，与镜片大小无关。
+
+| 瞄具 | 倍率 | 镜内实际放大 |
+|---|---|---|
+| ACOG TA31 | 2.5× | 2.5× |
+| ELCAN 4× | 4.25× | 4.25× |
+| 1873 6× | 6× | 6× |
+| 标准 8× | 8× | 8× |
+
+也就是说软化比初稿说的严重得多，**没有哪一档是「基本等同原生」的**。
+
+### 3.2 能做的两件事（已实现）
+
+真实细节找不回来 —— 信息量本来就不在主画面里。但重建质量和主观锐度都还有空间：
+
+1. **双三次重建（Catmull-Rom）取代硬件双线性。**
+   双线性在放大时就是线性插值，这种倍数下必然糊成一片；
+   Catmull-Rom 是插值型三次样条，放大时明显更锐利。
+   用 Matt Pettineo 那套「中间抽头合并成硬件双线性抽头」的写法，
+   4×4=16 次点采样降到 9 次 —— 前提是采样器必须是 `LINEAR`（合成阶段就是这么绑的）。
+   代价是高对比边缘会轻微过冲，结果需 `max(0.0)` 夹一下。
+2. **按倍率加权的钝化蒙版锐化。**
+   强度从 1× 的 0 线性升到 6× 的满值（`ScopePipSharpness` 控制上限，默认 0.5）。
+   低倍镜不会被过度处理，高倍镜也不会锐化不足。
+   抽头取在**源图**的相邻像素上（先锐化再放大）：高频细节只存在于源图的采样率上，
+   在放大后的坐标系里做邻域只会放大插值伪细节，而且每个抽头都要再跑一遍
+   Catmull-Rom，不划算。
+
+只有镜内像素会付这些采样开销 —— 镜外在更早的 `discard` 就退出了。
+
+### 3.3 真正的高倍清晰度需要什么
+
+只有回到「用窄 FOV 把世界再渲一遍」，那样镜内像素是原生渲染出来的。
+而那条路必须先解决 §1 的 Sodium 兼容问题，目前无解。
+
+---
+
+## 4. 判定链：谁能走 PIP
+
+`ScopePipRenderer.isEnabledForHeldGun()` 全部满足才走：
+
+| 条件 | 不满足时 |
+|---|---|
+| `ScopePipEnable` = true | 整屏变焦（改动前行为） |
+| `ScopeMaskEnable` = true | 同上（没有掩码就没有孔径，PIP 无处落地） |
+| 无光影包 | 同上 |
+| 第一人称、在世界里 | 同上 |
+| 装了**瞄具配件**且 `zoom > 1` | 同上 |
+
+再加一条**通道级**判据：`ScopeMaskRenderer.hasMaskThisFrame()`。
+
+它替代了「在这里重算一遍 sight / scope / 组合镜的分档」——
+那套状态机（`BedrockAttachmentModel#activeGroupIsScope`）牵扯 `views[]` 索引与
+目镜节点命名，复制一份必然走样。直接读模型自己的结论：
+**掩码没产出 = 这条通道不该走 PIP**，于是红点/全息、组合镜低倍档
+继续用整屏变焦，不会变成「既没 PIP 也没放大」。
+
+代价是一帧延迟（FOV 事件在 `extract` 阶段、掩码画在同帧稍后）。
+唯一读到旧值的时刻是刚抬镜那一帧，此时 `aimingProgress ≈ 0.02`，
+变焦公式 `1 + (zoom-1)·progress` 几乎等于原始 FOV，再过二阶平滑，推导上不可见。
+
+> 该标志在 `renderItemInHand` 的 HEAD 清零（`setInHandPass(true)` 里），
+> 不是在阶段边界清 —— 因为 `renderItemInHand` 有若干提前 return
+> （F1 隐藏 HUD、旁观者、第三人称、睡觉），走那些分支时根本到不了阶段边界，
+> 标志会粘住上一帧的值。
+
+---
+
+## 5. 失败姿态
+
+任何一环抛异常 → `failed = true` → 本特性永久停用（当次会话），并打一条 error 日志。
+此后 `applyScopeMagnification` 的整屏变焦在**下一帧**自动接管 ——
+它每帧重新问一次 `suppressesWorldFovZoom()`，不缓存。
+
+合成管线**懒加载**：本类的静态初始化会被每帧的 FOV 事件触发（不看 PIP 开没开），
+若管线在 `<clinit>` 里构建，一旦构建抛异常就是 `ExceptionInInitializerError`，
+连关着 PIP 的玩家都会被带崩。
+
+---
+
+## 6. 配置项
+
+| 键 | 默认 | 说明 |
+|---|---|---|
+| `ScopePipEnable` | `false` | 总开关 |
+| `ScopePipMinAimingProgress` | `0.05` | 低于该开镜进度不做 PIP |
+| `ScopePipSharpness` | `0.5` | 镜内锐化上限（0 = 关），实际强度按倍率加权 |
+| `ScopePipAllowShaderPacks` | `false` | 允许光影包启用时也跑 PIP，见 §7.3 |
+
+第一版的 `ScopePipResolutionScale` / `ScopePipUpdateInterval` **已删除**：
+前者只会让镜内更糊（拷贝必须满分辨率），后者会让镜内画面滞后，
+而拷贝本身已经足够便宜，两个都没有存在理由。
+
+---
+
+## 7. 已知缺口
+
+1. **高倍镜镜内变软**（§3），方案内不可消除。
+2. **镜内看不到发光实体的描边**：`levelRenderer.doEntityOutline()` 在
+   `renderLevel` 返回**之后**才把描边贴到主画面（GameRenderer 偏移 275），
+   而拷贝发生在那之前。观感差异，不影响正确性。
+3. **光影包下默认关闭，但可由 `ScopePipAllowShaderPacks` 打开。**
+
+   注意这里**不**沿用 `IrisCompat.shouldDisableScopeMaskUnderShaderPack()` 的结论 ——
+   那个方法对 Iris 返回 `false`（本仓库专门做了 `assignPipeline` → Iris HAND program
+   的兼容层，目镜掩码在光影下是支持的）。PIP 比掩码多两件**未验证**的事：
+
+   1. 抓取时机在 `LevelRenderer#render` 之后，而延迟管线的 composite 可能还没跑完，
+      拷到的也许是未着色的中间结果；
+   2. 合成写的是裸颜色，而光影通常在 tonemap 之前工作于线性/HDR 空间，
+      镜内可能偏灰或过曝。
+
+   两者都只是**观感**风险 —— 重投影不重新驱动世界渲染，不可能像第一版那样
+   打乱别的 mod 的逐帧状态。所以「打开试一眼」是安全的，
+   默认关是保守，不是「已知不兼容」。若实测证实可用，就把默认翻过来；
+   若确实偏色，那说明要挂到 Iris 的 composite 阶段之后再抓，届时再单独处理。
+4. `ScopePipTarget` 没有接到任何生命周期回调（与 `ScopeMaskTarget` 一致），
+   只在尺寸/格式变化时销毁重建。
+
+---
+
+## 8. 第二版首次实机需要确认的项
+
+1. **不崩**，且日志无 `[TACZ Scope] Scope PIP ... failed`。
+2. **镜外保持 1×** —— 本次改动的全部意义。
+3. **镜内是放大的，且地形/实体/一切都一起放大**（第一版正是这里失败的）。
+4. **镜内画面与镜外对齐**：孔径中心指向的物体应与不开镜时准星指向的一致。
+5. **镜内看不到枪**（拷贝时机正确的直接检验）。
+6. **准星仍在最上层**。
+7. **回归**：红点/全息、组合镜低倍档表现完全不变（走的还是整屏变焦老路）。
+8. **回归**：`ScopePipEnable=false` 时一切与改动前一致。
+9. 高倍镜（6×/8×）镜内的软化程度是否可接受 —— 这是要你拍板的观感问题。
+
+---
+
+## 9. 涉及文件
+
+| 文件 | 改动 |
+|---|---|
+| `client/render/scope/ScopePipRenderer.java` | 判定、抓取场景拷贝、重投影合成 |
+| `client/render/scope/ScopePipTarget.java` | 场景拷贝纹理的生命周期 |
+| `assets/tacz/shaders/core/scope_pip.fsh` | 合成片元着色器（重投影 + 掩码 discard） |
+| `client/render/scope/ScopeMaskRenderer.java` | 新增 `hasMaskThisFrame()` 及其置位/清零 |
+| `mixin/client/GameRendererMixin.java` | `renderLevel` 里注入场景拷贝 |
+| `mixin/client/FeatureRenderDispatcherMixin.java` | 阶段边界追加合成调用 |
+| `client/event/CameraSetupEvent.java` | PIP 生效时整屏变焦让位 |
+| `config/client/RenderConfig.java` | 2 个配置项（顺带清掉第 18 轮遗留的悬空注释与无主 `builder.comment`） |

--- a/src/main/java/com/tacz/guns/client/event/CameraSetupEvent.java
+++ b/src/main/java/com/tacz/guns/client/event/CameraSetupEvent.java
@@ -15,6 +15,7 @@ import com.tacz.guns.api.item.attachment.AttachmentType;
 import com.tacz.guns.api.item.gun.AbstractGunItem;
 import com.tacz.guns.api.item.nbt.AttachmentItemDataAccessor;
 import com.tacz.guns.api.modifier.ParameterizedCachePair;
+import com.tacz.guns.client.render.scope.ScopePipRenderer;
 import com.tacz.guns.client.renderer.item.AnimateGeoItemRenderer;
 import com.tacz.guns.client.resource.GunDisplayInstance;
 import com.tacz.guns.client.resource.index.ClientGunIndex;
@@ -100,6 +101,30 @@ public class CameraSetupEvent {
             ItemStack stack = KeepingItemRenderer.getRenderer().getCurrentItem();
             if (!(stack.getItem() instanceof IGun iGun)) {
                 float fov = WORLD_FOV_DYNAMICS.update((float) event.getFOV());
+                event.setFOV(fov);
+                return;
+            }
+            // 【镜内画中画】开着 PIP 时，倍镜的放大由镜内那一遍窄 FOV 世界渲染负责，
+            // 世界 FOV 必须原样不动 —— 否则镜外也跟着被拉近，两处放大叠在一起。
+            //
+            // 判据刻意【不看开镜进度】：抬镜途中若判据翻转，世界 FOV 会毫无理由地跳一下。
+            // PIP 生效时自始至终不碰世界 FOV，孔径自己会随进度张开。
+            //
+            // 每帧重新问一次、不缓存：PIP 若在运行期出错自我停用，
+            // 下一帧整屏变焦就自动接管，不会留下「既没 PIP 也没放大」的死角。
+            if (ScopePipRenderer.suppressesWorldFovZoom()) {
+                // 【倍率拆分】默认 ScopePipWorldZoomShare=0.0 时 worldZoom 恒为 1，
+                // magnificationToFov(1, fov) == fov，于是这里与「完全不动世界 FOV」逐位等价 ——
+                // 老行为一点没变。
+                //
+                // 玩家把它调大，就是在用「镜外放大一点」换「镜内清晰一点」：
+                // 世界放大 W 之后镜内只需再放大 Z/W，于是镜内拿到的真实像素多 W 倍。
+                // 合成那一侧会把 W 除掉（见 ScopePipRenderer 的两个 runComposite 调用），
+                // 两边相乘恒等于总倍率，所以镜内外看到的放大程度始终一致。
+                float worldZoom = ScopePipRenderer.currentWorldZoom();
+                float fov = WORLD_FOV_DYNAMICS.update(worldZoom > 1.0f
+                        ? (float) MathUtil.magnificationToFov(worldZoom, event.getFOV())
+                        : (float) event.getFOV());
                 event.setFOV(fov);
                 return;
             }

--- a/src/main/java/com/tacz/guns/client/render/scope/ScopeMaskRenderer.java
+++ b/src/main/java/com/tacz/guns/client/render/scope/ScopeMaskRenderer.java
@@ -148,8 +148,63 @@ public final class ScopeMaskRenderer {
             .withPrimitiveTopology(PrimitiveTopology.QUADS)
             .build();
 
+    /**
+     * 凸包顶点的 NDC 合理范围。视口是 [-1,1]，留一倍余量容纳部分出屏的目镜。
+     *
+     * <p>超出即判为近平面伪影：第一人称视模离相机极近，顶点擦过近平面时
+     * w 会小到让 NDC 飙上几百几千，一个这样的点就能把凸包撑满全屏。
+     */
+    private static final float NDC_SANITY_LIMIT = 2.0f;
+
     /** 顶点暂存区。复用同一个，避免每帧分配。 */
     private static final ByteBufferBuilder SCRATCH = new ByteBufferBuilder(4096);
+
+    /**
+     * 本帧目镜几何在 NDC 里的包围盒，{@code {minX, minY, maxX, maxY}}。
+     *
+     * <h3>它是干什么的</h3>
+     * 给镜内画面的合成加一道<b>硬件剪裁</b>。合成本来只靠着色器里的
+     * 「掩码为假就 discard」来约束范围，那是<b>软</b>约束 —— 掩码纹理一旦有任何问题
+     * （没绑上、内容不对、采样坐标错位），discard 就不触发，那张放大的世界会被
+     * <b>整屏</b>糊上去。用户实测到的「放大画面溢出到镜外、和正常画面撞在一起」正是这个形态。
+     *
+     * <p>而目镜几何在屏幕上的包围盒是我们<b>本来就算得出来</b>的东西。
+     * 用它开 scissor，合成就在物理上不可能画到镜片之外 ——
+     * 掩码依旧负责镜片内部的精确形状，scissor 负责「绝不越界」这条底线。
+     * 两道约束一软一硬，任何一道失效都还有另一道兜着。
+     */
+    private static final float[] MASK_BOUNDS_NDC = new float[4];
+    private static boolean maskBoundsValid = false;
+
+    /** 本帧是否算出了可用的目镜屏幕包围盒。 */
+    public static boolean hasMaskBounds() {
+        return maskBoundsValid;
+    }
+
+    /** @return {@code {minX, minY, maxX, maxY}}，NDC 空间；仅在 {@link #hasMaskBounds()} 为真时有效 */
+    public static float[] maskBoundsNdc() {
+        return MASK_BOUNDS_NDC;
+    }
+
+    /**
+     * 把一个 NDC 点并入本帧包围盒。
+     *
+     * <p>已经过 {@link #NDC_SANITY_LIMIT} 过滤，所以近平面伪影不会把盒子撑爆。
+     */
+    private static void accumulateBounds(float ndcX, float ndcY) {
+        if (!maskBoundsValid) {
+            maskBoundsValid = true;
+            MASK_BOUNDS_NDC[0] = ndcX;
+            MASK_BOUNDS_NDC[1] = ndcY;
+            MASK_BOUNDS_NDC[2] = ndcX;
+            MASK_BOUNDS_NDC[3] = ndcY;
+            return;
+        }
+        MASK_BOUNDS_NDC[0] = Math.min(MASK_BOUNDS_NDC[0], ndcX);
+        MASK_BOUNDS_NDC[1] = Math.min(MASK_BOUNDS_NDC[1], ndcY);
+        MASK_BOUNDS_NDC[2] = Math.max(MASK_BOUNDS_NDC[2], ndcX);
+        MASK_BOUNDS_NDC[3] = Math.max(MASK_BOUNDS_NDC[3], ndcY);
+    }
 
     private static boolean failed = false;
     private static boolean loggedSuccess = false;
@@ -168,6 +223,39 @@ public final class ScopeMaskRenderer {
      */
     private static boolean inHandPass = false;
 
+    /**
+     * 本帧掩码 target 里是否真有一张画好的掩码。
+     *
+     * <p>{@link ScopeMaskGeometry} 在 {@link #renderAtPhaseBoundary()} 的 finally 里
+     * 被无条件清空，所以<b>合成阶段没法再靠「清单空不空」判断本帧有没有掩码</b>。
+     * {@code ScopePipRenderer} 紧跟在掩码之后合成镜内画面，需要这个答案。</p>
+     *
+     * <h3>语义是「本帧任意时刻画过」，因此只能<b>每帧</b>清一次</h3>
+     * 早前的实现把它清在「每次手部 pass 开始时」，那在原版下没问题（一帧只有一次手部
+     * {@code renderAllFeatures}），但在 <b>Iris 光影下是错的</b>：
+     * {@code HandRenderer} 一帧里调用两次 —— {@code renderSolid} 与
+     * {@code renderTranslucent}，两次的 {@code ACTIVE} 都是 true（字节码实读）。于是：
+     * <pre>
+     * ① solid       清零 → 目镜几何在册 → 画掩码 → true
+     * ② translucent 清零 → 几何已被 ① 消费掉，清单是空的 → 提前 return → 【false】
+     * </pre>
+     * 每帧结束时恒为 false，{@code ScopePipRenderer} 于是永远看不到掩码，
+     * PIP 在光影下整个不工作、退回整屏变焦 —— 这正是用户实测到的现象。
+     *
+     * <p>改为每帧清一次之后，本标志在一帧之内是<b>单调</b>的（false → true，不会回落），
+     * 「本帧画过没有」这个语义才真正成立。
+     */
+    private static boolean maskDrawnThisFrame = false;
+
+    /**
+     * 上一帧的 {@link #maskDrawnThisFrame} 快照。
+     *
+     * <p>为什么需要它：掩码画在手部渲染里，而两个消费者跑在那之前 ——
+     * FOV 事件在 {@code extract} 阶段、镜内画面的抓取在 {@code renderLevel} 里。
+     * 它们要问的是「上一帧有没有掩码」，读当帧的值只会恒得 false。</p>
+     */
+    private static boolean maskDrawnLastFrame = false;
+
     private ScopeMaskRenderer() {
     }
 
@@ -177,6 +265,51 @@ public final class ScopeMaskRenderer {
 
     public static boolean isInHandPass() {
         return inHandPass || IrisCompat.isHandRendererActive();
+    }
+
+    /**
+     * 每帧开头调用一次，快照上一帧结果并把本帧归零。
+     *
+     * <p>接在 {@code GameRenderer#extract} 的 HEAD 上 —— 那是
+     * {@code Minecraft#runTick} 里 <b>extract(偏移 441) → render(偏移 520)</b>
+     * 这条顺序的最前面，因此本帧所有消费者（FOV 事件、镜内抓取、合成）
+     * 看到的都是同一份、定义明确的状态。</p>
+     *
+     * <p>刻意<b>不</b>放在手部 pass 里：Iris 一帧有两次手部 pass，
+     * 放那儿会被第二次抹掉，见 {@link #maskDrawnThisFrame} 的注释。</p>
+     */
+    public static void beginFrame() {
+        maskDrawnLastFrame = maskDrawnThisFrame;
+        maskDrawnThisFrame = false;
+        compositedThisFrame = false;
+    }
+
+    /** 本帧掩码是否已成功画进 target（供合成阶段判定 —— 它跑在掩码之后）。 */
+    public static boolean hasMaskThisFrame() {
+        return maskDrawnThisFrame;
+    }
+
+    /** 上一帧是否画出过掩码（供 FOV 让位与镜内抓取判定 —— 它们跑在掩码之前）。 */
+    public static boolean hadMaskLastFrame() {
+        return maskDrawnLastFrame;
+    }
+
+    /**
+     * 「镜内画面本帧已经合成过」的一次性闸门。
+     *
+     * <p>同样是 Iris 双手部 pass 惹的：合成若在 solid 与 translucent 两次都跑，
+     * 第二次会把 solid 阶段已经画进孔径的东西（蚀刻准星等）整片覆盖掉。
+     * 只允许本帧第一次手部 pass 合成。</p>
+     */
+    private static boolean compositedThisFrame = false;
+
+    /** @return true 表示本次调用取得了合成资格（每帧只有第一次调用会返回 true） */
+    public static boolean claimCompositeSlot() {
+        if (compositedThisFrame) {
+            return false;
+        }
+        compositedThisFrame = true;
+        return true;
     }
 
     /**
@@ -294,6 +427,9 @@ public final class ScopeMaskRenderer {
                     // 我们的顶点/索引都是从头开始的单批，所以 firstIndex 与 baseVertex 都是 0。
                     pass.drawIndexed(draw.indexCount(), 1, 0, 0, 0);
                 }
+                // 走到这里 pass 已经关闭、绘制已提交 —— 掩码 target 里确实有东西了。
+                // 镜内画中画的合成阶段就等这一位。
+                maskDrawnThisFrame = true;
                 if (!loggedSuccess) {
                     loggedSuccess = true;
                     GunMod.LOGGER.info("[TACZ Scope] Ocular mask drawn: {} indices from {} batches.",
@@ -346,6 +482,10 @@ public final class ScopeMaskRenderer {
     private static MeshData buildMesh() {
         BufferBuilder builder = new BufferBuilder(SCRATCH, PrimitiveTopology.QUADS, DefaultVertexFormat.POSITION);
         boolean hullFill = RenderConfig.SCOPE_MASK_HULL_FILL.get();
+        // 每帧重算目镜屏幕包围盒（供合成阶段开硬件剪裁）。
+        // 无论走凸包还是逐立方体描摹，都要算 —— 那道底线不能只在其中一条路上生效。
+        maskBoundsValid = false;
+        computeMaskBounds();
         for (ScopeMaskGeometry.Entry entry : ScopeMaskGeometry.entries()) {
             if (hullFill && writeHullFill(builder, entry.pose(), entry.cubes())) {
                 continue;
@@ -426,7 +566,22 @@ public final class ScopeMaskRenderer {
                     if (tmp.w <= 1.0e-6f) {
                         continue;
                     }
-                    pts.add(new float[]{tmp.x() / tmp.w, tmp.y() / tmp.w});
+                    float ndcX = tmp.x() / tmp.w;
+                    float ndcY = tmp.y() / tmp.w;
+                    // 【近平面炸包保护】w>0 还不够。瞄具是第一人称视模，离相机只有几厘米，
+                    // 而近平面是 0.05 —— 大幅转身/开镜过渡时，目镜的个别顶点会擦过近平面，
+                    // w 落到 0.001 这种量级，透视除法后 NDC 直接飙到 ±1000。
+                    // 凸包只要吃进一个这样的点就会撑满整个屏幕，掩码于是「全屏为真」，
+                    // 镜内画面被贴得到处都是 —— 用户实测「瞄着假人时完美，转身 190° 后
+                    // 放大的假人跑到镜外还是放大的」正是这个。
+                    //
+                    // 合法的目镜投影不可能离视口这么远，所以超出该范围的点一律判为
+                    // 近平面伪影丢弃。丢到不足 3 点时下面会回退逐立方体描摹（=旧行为），安全。
+                    if (!Float.isFinite(ndcX) || !Float.isFinite(ndcY)
+                            || Math.abs(ndcX) > NDC_SANITY_LIMIT || Math.abs(ndcY) > NDC_SANITY_LIMIT) {
+                        continue;
+                    }
+                    pts.add(new float[]{ndcX, ndcY});
                 }
             }
         }
@@ -479,6 +634,50 @@ public final class ScopeMaskRenderer {
             emitNdcAsQuad(builder, invProj, p0, hull.get(i), hull.get(i + 1));
         }
         return true;
+    }
+
+    /**
+     * 算出本帧全部目镜几何在 NDC 里的包围盒。
+     *
+     * <p>投影矩阵的取法与 {@link #writeHullFill} 完全同源（读同一份投影 UBO），
+     * 所以盒子与掩码画出来的形状严格在同一个坐标系里，不会错位。
+     * 读不到投影就不设包围盒 —— 合成阶段随之跳过剪裁，退回纯掩码约束（= 旧行为）。
+     */
+    private static void computeMaskBounds() {
+        if (ScopeMaskGeometry.isEmpty()) {
+            return;
+        }
+        Matrix4f proj = new Matrix4f();
+        try (GpuBufferSlice.MappedView view = RenderSystem.getProjectionMatrixBuffer().map(true, false)) {
+            proj.set(view.data());
+        } catch (Exception e) {
+            return;
+        }
+        Vector4f tmp = new Vector4f();
+        for (ScopeMaskGeometry.Entry entry : ScopeMaskGeometry.entries()) {
+            for (BedrockCube cube : entry.cubes()) {
+                for (var polygon : cube.getPolygons()) {
+                    if (polygon == null) {
+                        continue;
+                    }
+                    for (var vertex : polygon.vertices) {
+                        tmp.set(vertex.pos.x() / 16.0F, vertex.pos.y() / 16.0F, vertex.pos.z() / 16.0F, 1.0F);
+                        tmp.mul(entry.pose());
+                        tmp.mul(proj);
+                        if (tmp.w <= 1.0e-6f) {
+                            continue;
+                        }
+                        float ndcX = tmp.x() / tmp.w;
+                        float ndcY = tmp.y() / tmp.w;
+                        if (!Float.isFinite(ndcX) || !Float.isFinite(ndcY)
+                                || Math.abs(ndcX) > NDC_SANITY_LIMIT || Math.abs(ndcY) > NDC_SANITY_LIMIT) {
+                            continue;
+                        }
+                        accumulateBounds(ndcX, ndcY);
+                    }
+                }
+            }
+        }
     }
 
     /** 单调链叉积：(b−a)×(c−a) 的 z 分量。 */

--- a/src/main/java/com/tacz/guns/client/render/scope/ScopePipRenderer.java
+++ b/src/main/java/com/tacz/guns/client/render/scope/ScopePipRenderer.java
@@ -880,6 +880,9 @@ public final class ScopePipRenderer {
         if (!isEnabledForHeldGun()) {
             return;
         }
+        // 让诊断 trace 知道「这一帧真的合成了」—— 光影下没有 SCOPE-PASS，
+        // 只有这里能给它一个可扣预算的信号。见 ScopePipTrace.ARMED_FRAME_LIMIT 的说明。
+        ScopePipTrace.mark("PIP COMPOSITE (screen space, after the Iris pipeline finished)");
         // 【倍率跟着开镜进度走】这条路的素材是最终画面，画面里是有枪的 ——
         // 干净的世界像素只存在于孔径那一块。抬镜过程中瞄具还没移到屏幕中心，
         // 而重投影的采样点恒定绕屏幕中心收缩，此时那块可能还压在枪身上，

--- a/src/main/java/com/tacz/guns/client/render/scope/ScopePipRenderer.java
+++ b/src/main/java/com/tacz/guns/client/render/scope/ScopePipRenderer.java
@@ -1,0 +1,1037 @@
+package com.tacz.guns.client.render.scope;
+
+import com.mojang.blaze3d.GpuFormat;
+import com.mojang.blaze3d.ProjectionType;
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
+import com.mojang.blaze3d.pipeline.BindGroupLayout;
+import com.mojang.blaze3d.pipeline.ColorTargetState;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.pipeline.TextureTarget;
+import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.systems.RenderPass;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.textures.FilterMode;
+import com.mojang.blaze3d.textures.GpuTexture;
+import com.tacz.guns.GunMod;
+import com.tacz.guns.api.DefaultAssets;
+import com.tacz.guns.api.TimelessAPI;
+import com.tacz.guns.api.client.gameplay.IClientPlayerGunOperator;
+import com.tacz.guns.api.client.other.KeepingItemRenderer;
+import com.tacz.guns.api.item.IGun;
+import com.tacz.guns.api.item.attachment.AttachmentType;
+import com.tacz.guns.api.item.nbt.AttachmentItemDataAccessor;
+import com.tacz.guns.compat.iris.IrisCompat;
+import com.tacz.guns.compat.sodium.SodiumCompat;
+import com.tacz.guns.config.client.RenderConfig;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.renderer.BindGroupLayouts;
+import net.minecraft.client.renderer.Projection;
+import net.minecraft.client.renderer.ProjectionMatrixBuffer;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.client.renderer.fog.FogRenderer;
+import net.minecraft.client.renderer.state.GameRenderState;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
+import com.tacz.guns.util.math.MathUtil;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.Mth;
+import net.minecraft.world.item.ItemStack;
+import org.joml.Matrix4f;
+import org.joml.Vector4f;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+/**
+ * 瞄准镜「镜内画中画（PIP）」渲染。
+ *
+ * <h2>它改变了什么</h2>
+ * 移植自上游的原方案里，「镜内放大」其实是<b>整屏</b> FOV 变焦
+ * （{@code CameraSetupEvent#applyScopeMagnification} 压小世界 FOV），
+ * 镜片只是被掏空、让已经放大的主画面原样透出来。观感上整个屏幕都在变焦，
+ * 镜筒外的世界也跟着放大 —— 这不是真实瞄具的样子。
+ *
+ * <p>本类让镜外保持 1×，只有镜片里是放大的。
+ *
+ * <h2>两种模式</h2>
+ * 由 {@code ScopePipRerender} 切换，合成阶段共用同一条通路：
+ * <table border="1">
+ *   <caption>镜内画面从哪来</caption>
+ *   <tr><th></th><th>重投影（默认）</th><th>二次渲染</th></tr>
+ *   <tr><td>镜内画面</td><td>主画面拷贝 + 屏幕空间等比放大</td><td>窄 FOV 真画一遍</td></tr>
+ *   <tr><td>镜内分辨率</td><td>屏幕分辨率 ÷ 倍率（8× 下很糊）</td><td>原生</td></tr>
+ *   <tr><td>每帧代价</td><td>一次全屏拷贝</td><td>一整遍世界渲染</td></tr>
+ *   <tr><td>兼容性</td><td>只读最终颜色缓冲，天然兼容</td><td>要同步 Sodium 的投影快照，见 {@code SodiumCompat}</td></tr>
+ * </table>
+ *
+ * <h2>重投影模式的原理</h2>
+ * 关键的几何事实（见 {@link ScopePipTarget} 的类注释）：透视投影下，
+ * 「把 FOV 压窄 Z 倍」在屏幕空间<b>恒等于</b>「绕光轴把画面放大 Z 倍」。
+ * 于是镜内那张图不必重新渲染，只要对已经画好的世界按
+ * <pre>
+ * wideUV = center + (narrowUV − center) / Z
+ * </pre>
+ * 重采样即可 —— 结果与「用窄 FOV 重渲一遍」<b>逐像素等价</b>（分辨率除外）。
+ *
+ * <p>每帧只多做两件事：一次全屏纹理拷贝、一次全屏三角形绘制。
+ *
+ * <h2>二次渲染那条路的历史（读之前先读这段）</h2>
+ * 它是本特性的第一版，实测在 Sodium 环境下画面崩坏，一度被整体否决。
+ * 事后逐条反编译 Sodium 0.9.1 才查清真正的机理 —— <b>与最初的判断不同</b>：
+ * <ul>
+ *   <li>Sodium <b>确实</b>走 {@code GameRenderer#mainRenderTarget()}
+ *       （{@code TerrainRenderPass} 字节码实读），所以<b>重定向对它是有效的</b>。
+ *       最初「Sodium 完全绕开该方法」的判断是错的；</li>
+ *   <li>真正的病灶是<b>投影矩阵</b>：Sodium 用
+ *       {@code GameRendererStorage.sodium$getProjectionMatrix()} 里自己快照的那一份
+ *       （由它 {@code WrapOperation} 包住 {@code ProjectionMatrixBuffer#getBuffer}
+ *       在 {@code renderLevel} 里抓取），<b>不看</b>
+ *       {@code RenderSystem.setProjectionMatrix}。第一版只改了后者，
+ *       于是地形用宽 FOV、原版路径的实体用窄 FOV，两套比例糊在一起；</li>
+ *   <li>另外，一帧内两次驱动 {@code LevelRenderer#render} 会打乱某处的逐帧状态
+ *       → <b>镜外</b>的实体与部分物件整个消失。<b>这一条至今未查清</b>。
+ *       已排除的嫌疑：ImmediatelyFast 的
+ *       {@code avoid_redundant_framebuffer_switching}（它只是跳过绑定 FBO 0，
+ *       不缓存「当前绑定的是谁」）。</li>
+ * </ul>
+ * 投影那条已由 {@code SodiumCompat} 修好，所以二次渲染重新开放为实验开关；
+ * 第三条未解，这是它默认关闭的原因。
+ *
+ * <p>重投影方案没有这些问题：只读<b>最终颜色缓冲</b>，
+ * 那些像素是谁画的、用什么投影画的都无所谓。
+ *
+ * <h2>代价：镜内分辨率上限 = 屏幕分辨率 ÷ 倍率</h2>
+ * 合成是对<b>整屏</b>做重投影，镜片只是这张重投影图上的一个窗口：
+ * 屏幕上直径 D 的镜片，其像素映射回原画面只覆盖 {@code D / Z} 个像素，
+ * 却要铺满 D 个像素 ⇒ <b>放大倍数恒等于 Z</b>，与镜片大小无关。
+ * 6 倍镜就是 6× 放大，必然明显变软。
+ *
+ * <p>着色器侧用 Catmull-Rom 双三次重建 + 按倍率加权的锐化尽量挽回主观锐度，
+ * 但<b>真实细节找不回来</b> —— 信息量本来就不在主画面里。
+ * 要真正的高倍清晰度只能回到二次渲染，而那条路卡在上面第三条。
+ *
+ * <h2>合成时机：掩码画完、镜身画之前</h2>
+ * {@code renderItemInHand → renderAllFeatures} 的阶段边界，
+ * {@link ScopeMaskRenderer#renderAtPhaseBoundary()} 之后立刻合成：
+ * <pre>
+ * 掩码画好          → 知道镜内是哪些像素
+ * 【合成 PIP】      → 那些像素被贴上放大后的世界
+ * executeSolid 起  → 镜身在镜内 discard（掩码），于是 PIP 画面留住；
+ *                    准星反向裁剪（只画镜内），于是浮在 PIP 画面之上
+ * </pre>
+ * 若挪到手持渲染之后，准星就会被 PIP 盖掉；若挪到掩码之前，掩码还没就绪。
+ *
+ * <h2>失败即退回，永不加剧</h2>
+ * 任何一环出问题都会把 {@link #failed} 置位并永久停用本特性。此后
+ * {@code applyScopeMagnification} 的整屏变焦会在<b>下一帧</b>自动恢复 ——
+ * 因为它每帧都重新问一次 {@link #suppressesWorldFovZoom()}，不缓存。
+ * 最坏情况是回到现有已验证行为，不会出现「既没有 PIP 也没有放大」的死角。
+ */
+@Environment(EnvType.CLIENT)
+public final class ScopePipRenderer {
+
+    /** 合成用的掩码采样器名。与 {@code ScopeBodyRenderTypes} 那份同名不同 layout，互不影响。 */
+    private static final String MASK_SAMPLER = "ScopeMaskSampler";
+
+    /**
+     * 合成管线：一个全屏三角形，按倍率重采样场景拷贝，按掩码 discard。
+     *
+     * <h3>配方来源</h3>
+     * 逐项对照 vanilla {@code ENTITY_OUTLINE_BLIT}（{@code RenderPipelines.<clinit>}
+     * 偏移 5367-5437 实读）与它的用法 {@code RenderTarget#blitAndBlendToTexture}：
+     * <pre>
+     * builder(GLOBALS_SNIPPET)
+     *     .withVertexShader("core/screenquad")   // 无顶点缓冲，靠 gl_VertexID 造三角形
+     *     .withFragmentShader("core/blit_screen")
+     *     .withBindGroupLayout(BindGroupLayouts.IN_SAMPLER)
+     *     .withPrimitiveTopology(TRIANGLES)
+     * </pre>
+     * 这里 {@code GLOBALS_SNIPPET} 是 private，但 {@code POST_PROCESSING_SNIPPET}
+     * 就是 {@code builder(GLOBALS_SNIPPET).withPrimitiveTopology(TRIANGLES)}
+     * （偏移 1120-1142 实读）且是 public —— 正好等价，直接用它当底子。
+     *
+     * <h3>与 vanilla 的差异</h3>
+     * <ul>
+     *   <li>片元着色器换成我们的 {@code tacz:core/scope_pip}（重采样 + 掩码 discard）；</li>
+     *   <li>多绑一个掩码采样器 layout；</li>
+     *   <li>多绑 {@code DYNAMIC_TRANSFORMS}，借 {@code ColorModulator.r} 把倍率送进去。
+     *       {@code bindDefaultUniforms} 不管这个块，得自己 {@code setUniform}
+     *       —— 与 {@code ScopeMaskRenderer} 同一套路。</li>
+     * </ul>
+     *
+     * <h3>写掩码取 {@code WRITE_COLOR} 而不是 {@code WRITE_ALL}</h3>
+     * 镜内画面只该改颜色。主 target 的 alpha 通道后面还要参与 GUI/后处理的混合，
+     * 顺手覆写会引入难查的偏差 —— vanilla 的 {@code ENTITY_OUTLINE_BLIT} 同样传 7。
+     *
+     * <h3>不声明 DepthStencilState</h3>
+     * 合成是纯屏幕空间的覆盖：镜内像素无条件换成镜内画面，不参与深度测试，
+     * 也不该写深度（写了会让紧接着画的准星被判成遮挡）。
+     * {@code RenderPipeline#wantsDepthTexture()} 的判据是「字段是否为 null」，
+     * 所以这里必须<b>不设</b>，而不是设一个 ALWAYS_PASS ——
+     * 这条坑 {@code ScopeMaskRenderer} 已经踩过一次，别再踩。
+     *
+     * <h3>为什么是懒加载而不是 static final</h3>
+     * 本类的静态初始化会被 {@code CameraSetupEvent} 的 FOV 事件触发 ——
+     * 那是<b>每帧、且不看 PIP 开没开</b>的路径。若管线在 {@code <clinit>} 里构建，
+     * 一旦构建抛异常（版本漂移、层名对不上）就是 {@code ExceptionInInitializerError}，
+     * 连关着 PIP 的玩家都会被带崩。放进真正要用它的那一步，
+     * 就落在 {@link #compositeAtPhaseBoundary()} 的 try/catch 里，最坏只是自我停用。
+     */
+    @Nullable
+    private static RenderPipeline compositePipeline;
+
+    private static RenderPipeline compositePipeline() {
+        if (compositePipeline == null) {
+            BindGroupLayout maskLayout = BindGroupLayout.builder().withSampler(MASK_SAMPLER).build();
+            compositePipeline = RenderPipeline.builder(RenderPipelines.POST_PROCESSING_SNIPPET)
+                    .withLocation(Identifier.fromNamespaceAndPath(GunMod.MOD_ID, "pipeline/scope_pip_composite"))
+                    .withVertexShader("core/screenquad")
+                    .withFragmentShader(Identifier.fromNamespaceAndPath(GunMod.MOD_ID, "core/scope_pip"))
+                    .withBindGroupLayout(BindGroupLayouts.IN_SAMPLER)
+                    .withBindGroupLayout(maskLayout)
+                    .withBindGroupLayout(BindGroupLayouts.DYNAMIC_TRANSFORMS)
+                    .withColorTargetState(new ColorTargetState(
+                            Optional.empty(), GpuFormat.RGBA8_UNORM, ColorTargetState.WRITE_COLOR))
+                    .build();
+        }
+        return compositePipeline;
+    }
+
+    /** 场景纹理里是否有一张可用的本帧镜内画面。 */
+    private static boolean sceneCaptured = false;
+
+    /**
+     * 「{@code mainRenderTarget()} 正在被重定向」窗口，同时就是要顶上去的那个 target。
+     *
+     * <p>只在二次渲染模式下、{@code LevelRenderer#render} 那一次调用期间非空。
+     * 存引用而不是 boolean + 现查：一次世界渲染里 {@code mainRenderTarget()} 会被问很多次，
+     * 中途若变成 null，剩下的绘制就会落回主画面，表现为「半张世界画在屏幕上」。
+     */
+    @Nullable
+    private static RenderTarget redirectTarget = null;
+
+    /** 二次渲染的投影暂存。首次使用时创建（构造需要 GPU 设备就绪）。 */
+    @Nullable
+    private static ProjectionMatrixBuffer projectionBuffer;
+    private static final Projection PROJECTION = new Projection();
+    /** 传给 Sodium 的窄投影矩阵，复用避免每帧分配。 */
+    private static final Matrix4f NARROW_MATRIX = new Matrix4f();
+
+    /**
+     * {@code GameRendererMixin} 的 {@code mainRenderTarget()} 注入点读这里。
+     *
+     * @return 需要顶替主 target 时返回离屏 target；其余一切时候返回 {@code null}（不干预）
+     */
+    @Nullable
+    public static RenderTarget redirectTarget() {
+        return redirectTarget;
+    }
+
+    private static boolean loggedShaderRerenderBlock = false;
+
+    /**
+     * 是否走二次渲染。<b>光影启用时强制否</b>。
+     *
+     * <h3>为什么光影下必须禁掉二次渲染</h3>
+     * 与 Sodium 那个 {@code hasUpdatedThisFrame} 是同一类病：<b>逐帧状态被驱动了两遍</b>。
+     * 光影下 {@code LevelRenderer#render} 带动的是 Iris 的整条延迟管线 ——
+     * gbuffers、composite 链，以及各 shaderpack 用来做时域累积（TAA）的
+     * {@code colortex} main/alt <b>乒乓翻转</b>。一帧翻两次，下一帧的历史缓冲就取错了源，
+     * 整屏出现噪点、像掉了分辨率。用户实测「开光影后没有 PIP，反而整屏都是噪点、像低分辨率」
+     * 正是这个形态。
+     *
+     * <p>所以这里硬性拦下：光影下即便配置写了 {@code ScopePipRerender=true} 也退回重投影。
+     * 重投影只读一张已完成的颜色缓冲，不驱动任何管线，不会污染时域状态。
+     *
+     * <p>（重投影在光影下<b>也还不能正常出图</b>，原因不同 ——
+     * 抓取点拿到的主 target 在 Iris 下尚未被 {@code FinalPassRenderer} 写入。
+     * 那是另一件事，见 {@link #inactiveReason()} 里的光影闸门。
+     * 这里只负责一件事：<b>不要把整屏搞坏</b>。）
+     */
+    private static boolean rerenderMode() {
+        boolean configured = RenderConfig.SCOPE_PIP_RERENDER != null && RenderConfig.SCOPE_PIP_RERENDER.get();
+        if (configured && IrisCompat.isUsingRenderPack()) {
+            if (!loggedShaderRerenderBlock) {
+                loggedShaderRerenderBlock = true;
+                GunMod.LOGGER.info("[TACZ Scope] ScopePipRerender is ignored while a shader pack is active: "
+                        + "driving the shader pipeline twice per frame corrupts its temporal buffers "
+                        + "(screen-wide noise). Falling back to reprojection.");
+            }
+            return false;
+        }
+        return configured;
+    }
+
+    /** 一旦出过错就永久停用。 */
+    private static boolean failed = false;
+
+    private static boolean loggedFirstCapture = false;
+
+    private ScopePipRenderer() {
+    }
+
+    // ------------------------------------------------------------------
+    // 判定
+    // ------------------------------------------------------------------
+
+    /**
+     * 是否该让 {@code CameraSetupEvent#applyScopeMagnification} 的整屏变焦让位给 PIP。
+     *
+     * <p>让位是有前提的：<b>只有真正会产出目镜掩码的通道才能走 PIP</b>。
+     * 掩码没产出 = 合成阶段贴不进任何像素，此时若还把整屏变焦也关掉，
+     * 那把枪就彻底没有放大了 —— 这正是红点/全息与组合镜低倍档的处境
+     * （{@code BedrockAttachmentModel#activeGroupIsScope} 判定为 sight 通道时
+     * 不登记目镜几何，因为上游 {@code renderSight} 本来就不裁镜身）。</p>
+     *
+     * <p>判据直接取模型自己的结论（{@link ScopeMaskRenderer#hasMaskThisFrame()}），
+     * 而不是在这里重算一遍 sight/scope/组合镜的分档 ——
+     * 那套状态机牵扯 {@code views[]} 索引与目镜节点命名，复制一份必然走样。</p>
+     *
+     * <h3>关于一帧延迟</h3>
+     * FOV 事件发生在 {@code extract} 阶段，掩码画在同一帧稍后的手持渲染里，
+     * 所以这里读到的是<b>上一帧</b>的结论。这不构成问题：
+     * 唯一会读到「旧值 false」的时刻是刚开始抬镜的那一帧，
+     * 而那一帧 {@code aimingProgress ≈ 0.02}，变焦公式
+     * {@code 1 + (zoom - 1) * progress} 算出来几乎就是原始 FOV，
+     * 再经 {@code WORLD_FOV_DYNAMICS} 二阶平滑，肉眼不可见。收镜时同理对称。
+     */
+    public static boolean suppressesWorldFovZoom() {
+        return isEnabledForHeldGun();
+    }
+
+    /**
+     * 【诊断】上一次报告过的闸门状态，以及报告时刻。
+     *
+     * <p>本特性有七道闸门，任何一道不满足都表现为「PIP 没生效、还是整屏变焦」——
+     * 而这七种情况在画面上<b>完全一样</b>，纯靠肉眼无法区分是配置没生效、
+     * 是瞄具通道不对、还是光影拦住了。每次状态<b>变化</b>时打一行日志，
+     * 把「为什么没生效」变成一个可读的事实，省掉来回猜。</p>
+     */
+    private static String lastReportedGate = "";
+    private static int gateChangeCount = 0;
+    private static final int GATE_LOG_LIMIT = 40;
+
+    private static void reportGate(@Nullable String reason) {
+        // 功能整个关着的时候不吭声，否则对不用这个特性的玩家就是刷屏。
+        if (RenderConfig.SCOPE_PIP_ENABLE == null || !RenderConfig.SCOPE_PIP_ENABLE.get()) {
+            return;
+        }
+        String now = reason == null ? "ACTIVE" : reason;
+        if (now.equals(lastReportedGate)) {
+            return;
+        }
+        lastReportedGate = now;
+        gateChangeCount++;
+        // 【不做时间限流】第一版按「两秒最多一条」限流，结果把一次【逐帧抖动】
+        // 打印成了整齐的两秒间隔，看上去就像玩家在正常地抬镜/收镜 ——
+        // 真正的病灶（Iris 双手部 pass 把标志抹掉，导致判据每帧翻转）
+        // 反而被日志的形状藏住了。诊断日志把病症整形成正常样，比没有日志更糟。
+        //
+        // 改成「按变化打印 + 总量封顶」：抖动会以密集的连续行原形毕露，
+        // 又不会无限刷屏。
+        if (gateChangeCount <= GATE_LOG_LIMIT) {
+            GunMod.LOGGER.info("[TACZ Scope] Scope PIP gate -> {}", now);
+            if (gateChangeCount == GATE_LOG_LIMIT) {
+                GunMod.LOGGER.info("[TACZ Scope] Scope PIP gate changed {} times; muting further gate logs. "
+                        + "If those lines were alternating rapidly, the gate is flapping, not settling.",
+                        GATE_LOG_LIMIT);
+            }
+        }
+    }
+
+    private static boolean isEnabledForHeldGun() {
+        String reason = inactiveReason();
+        reportGate(reason);
+        return reason == null;
+    }
+
+    /**
+     * @return {@code null} 表示七道闸门全过；否则返回卡在哪一道的可读说明
+     */
+    @Nullable
+    private static String inactiveReason() {
+        if (failed) {
+            return "disabled after a runtime failure (see the earlier error above)";
+        }
+        if (RenderConfig.SCOPE_PIP_ENABLE == null || !RenderConfig.SCOPE_PIP_ENABLE.get()) {
+            return "ScopePipEnable is off";
+        }
+        // 合成完全依赖目镜掩码提供「镜内是哪些像素」。掩码关掉时 PIP 无从落地，
+        // 此时必须让整屏变焦继续生效，否则倍镜等于失效。
+        if (RenderConfig.SCOPE_MASK_ENABLE == null || !RenderConfig.SCOPE_MASK_ENABLE.get()) {
+            return "ScopeMaskEnable is off (PIP needs the ocular mask to know where the lens is)";
+        }
+        // 掩码自己判定不安全的环境（目前是 Sulkan），PIP 无条件跟着关 ——
+        // 没有掩码就没有孔径，谈不上贴图。
+        if (IrisCompat.shouldDisableScopeMaskUnderShaderPack()) {
+            return "the ocular mask reports this renderer as unsafe (Sulkan)";
+        }
+        // 光影包：默认关，但可由玩家打开。
+        //
+        // 这里刻意【不】沿用 shouldDisableScopeMaskUnderShaderPack 的结论 ——
+        // 那个方法对 Iris 返回 false（本仓库专门做了 assignPipeline → Iris HAND program
+        // 的兼容层，目镜掩码在光影下是支持的）。PIP 比掩码多两件未验证的事：
+        //   1. 抓取时机在 LevelRenderer#render 之后，而延迟管线的 composite 可能还没跑完，
+        //      拷到的也许是未着色的中间结果；
+        //   2. 合成写的是裸颜色，而光影通常在 tonemap 之前工作于线性/HDR 空间，
+        //      镜内可能偏灰或过曝。
+        // 两者都只是【观感】风险 —— 重投影不重新驱动世界渲染，
+        // 不可能像第一版那样打乱别的 mod 的逐帧状态，所以「打开试一眼」是安全的。
+        // 默认关是保守，不是「已知不兼容」。
+        if (IrisCompat.isUsingRenderPack() && !allowShaderPacks()) {
+            return "a shader pack is active and ScopePipAllowShaderPacks is off";
+        }
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.level == null || mc.player == null) {
+            return "no level/player";
+        }
+        if (!mc.options.getCameraType().isFirstPerson()) {
+            return "not in first person";
+        }
+        if (scopeMagnification() <= 1.0f) {
+            return "held gun has no scope attachment with zoom > 1 (iron sights and 1x optics keep the old FOV zoom)";
+        }
+        // 最后一道，也是最容易被误判成「PIP 坏了」的一道：目镜掩码到底有没有产出。
+        // 没有 = 当前是 sight 通道（红点/全息/组合镜低倍档），或者掩码链路在当前
+        // 渲染环境下没跑起来。两种都必须让整屏变焦继续接管。
+        //
+        // 【两个快照都认】本方法被三个时机调用，各自该看哪一份并不相同：
+        //   FOV 让位（extract 阶段）、镜内抓取（renderLevel 里）→ 本帧掩码还没画，看上一帧；
+        //   合成（手部 pass，掩码刚画完）                        → 看本帧。
+        // 取「上一帧或本帧画过」这个并集，三个时机就都成立，
+        // 也不必给调用方分叉出两套判据。
+        if (!ScopeMaskRenderer.hadMaskLastFrame() && !ScopeMaskRenderer.hasMaskThisFrame()) {
+            return "no ocular mask produced (sight/red-dot channel, or the mask pass is not running "
+                    + "in this renderer setup)";
+        }
+        return null;
+    }
+
+    /**
+     * 当前瞄具配件的倍率；没装倍镜（含机瞄）时返回 1。
+     *
+     * <h3>为什么按配件取而不是 {@code IGun#getAimingZoom}</h3>
+     * 后者把机瞄的 {@code ironZoom}（默认枪包里普遍是 1.2~1.5）也算进来。
+     * 机瞄<b>没有</b> {@code ocular} 骨骼，掩码永远是空的 —— PIP 贴不进任何像素，
+     * 却顺带丢掉了整屏变焦。所以这里只认真正的瞄具配件，
+     * 口径与用户的诉求（scope attachment）一致。
+     *
+     * <p>取档逻辑与 {@code MouseHandlerMixin#reduceSensitivity} 逐行同源：
+     * {@code zoom[zoomNumber % zoom.length]}，组合镜切档自动跟随。
+     */
+    private static float scopeMagnification() {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.player == null) {
+            return 1.0f;
+        }
+        ItemStack stack = KeepingItemRenderer.getRenderer().getCurrentItem();
+        if (!(stack.getItem() instanceof IGun iGun)) {
+            return 1.0f;
+        }
+        Identifier scopeId = iGun.getAttachmentId(stack, AttachmentType.SCOPE);
+        if (DefaultAssets.isEmptyAttachmentId(scopeId)) {
+            scopeId = iGun.getBuiltInAttachmentId(stack, AttachmentType.SCOPE);
+        }
+        if (DefaultAssets.isEmptyAttachmentId(scopeId)) {
+            return 1.0f;
+        }
+        return TimelessAPI.getClientAttachmentIndex(scopeId).map(index -> {
+            float[] zoom = index.getZoom();
+            if (zoom == null || zoom.length == 0) {
+                return 1.0f;
+            }
+            CompoundTag scopeTag = iGun.getAttachmentTag(stack, AttachmentType.SCOPE);
+            int zoomNumber = AttachmentItemDataAccessor.getZoomNumberFromTag(scopeTag);
+            return zoom[Math.floorMod(zoomNumber, zoom.length)];
+        }).orElse(1.0f);
+    }
+
+    /**
+     * 光影路径专用：本帧是否该在 Iris 的帧缓冲里合成镜内画面。
+     *
+     * <p>与无光影路径共用同一套闸门（配件倍率、第一人称、开镜进度、掩码通道），
+     * 只是<b>反过来</b>要求光影处于启用状态 —— 那条路只在 Iris 管线里才成立。
+     *
+     * <p>掩码判据取 {@link ScopeMaskRenderer#hadMaskLastFrame()}：合成点在手部 pass 之前，
+     * 本帧的掩码还没画出来。这就是那一帧延迟的来源，见 {@code IrisScopePip} 的说明。
+     */
+    public static boolean wantsIrisComposite() {
+        if (failed) {
+            return false;
+        }
+        if (RenderConfig.SCOPE_PIP_ENABLE == null || !RenderConfig.SCOPE_PIP_ENABLE.get()) {
+            return false;
+        }
+        if (RenderConfig.SCOPE_MASK_ENABLE == null || !RenderConfig.SCOPE_MASK_ENABLE.get()) {
+            return false;
+        }
+        if (!allowShaderPacks() || !IrisCompat.isUsingRenderPack()) {
+            return false;
+        }
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.level == null || mc.player == null || !mc.options.getCameraType().isFirstPerson()) {
+            return false;
+        }
+        if (scopeMagnification() <= 1.0f) {
+            return false;
+        }
+        if (currentAimingProgress() <= minAimingProgress()) {
+            return false;
+        }
+        return ScopeMaskRenderer.hadMaskLastFrame();
+    }
+
+    /** 供光影合成路径读取当前倍率。 */
+    public static float currentMagnification() {
+        return Math.max(1.0f, scopeMagnification());
+    }
+
+    // ------------------------------------------------------------------
+    // 倍率拆分：世界放大 W × 镜内放大 P = 瞄具倍率 Z
+    // ------------------------------------------------------------------
+
+    /**
+     * 镜外世界要跟着放大多少倍（满开镜时）。
+     *
+     * <h3>它解决的是镜内分辨率，而且是唯一能真正解决的办法</h3>
+     * 镜内画面是主画面中心那一小块放大来的：放大 Z 倍，就只有 {@code 1/Z} 的屏幕像素可用 ——
+     * 这是<b>信息量</b>上限，锐化、双三次重建都只能改善主观锐度，变不出真实细节。
+     * 唯一的出路是<b>让镜内少放大一点</b>：世界先放大 W，镜内只需再放大 {@code Z/W}，
+     * 于是镜内拿到的真实像素<b>多 W 倍</b>。
+     *
+     * <p>代价正是 PIP 存在的意义本身（镜外保持 1×），所以默认 {@code 1.0} = 一点都不让，
+     * 由玩家自己在「镜外纯净」与「镜内清晰」之间挑。
+     *
+     * <p>取值被瞄具倍率夹住：{@code W = Z} 时镜内不再放大，本特性退化成改动前的整屏变焦
+     * —— 那一档反而是最清晰的（镜内像素全部原生），这条连续性正是这个旋钮的下界与上界。
+     *
+     * <h3>二次渲染模式恒返回 1</h3>
+     * 那条路的镜内像素是用窄 FOV <b>真画出来的</b>，本来就没有分辨率上限，
+     * 让世界放大只会白白牺牲镜外画质、换不到任何东西。
+     */
+    private static float worldZoomTarget() {
+        if (rerenderMode()) {
+            return 1.0f;
+        }
+        if (RenderConfig.SCOPE_PIP_WORLD_ZOOM_SHARE == null) {
+            return 1.0f;
+        }
+        float share = Mth.clamp(RenderConfig.SCOPE_PIP_WORLD_ZOOM_SHARE.get().floatValue(), 0.0f, 1.0f);
+        if (share <= 0.0f) {
+            return 1.0f;
+        }
+        float zoom = Math.max(1.0f, scopeMagnification());
+        // 【为什么是 Z^share 而不是「允许的最大世界倍率」】
+        //
+        // 第一版给的是绝对上限 ScopePipMaxWorldZoom，它有个致命缺陷：W 被 Z 夹住，
+        // 于是任何 >= Z 的取值都得到 W = Z ⇒ 镜内倍率 Z/W = 1 ⇒ **镜内彻底不放大了**，
+        // PIP 名存实亡。而那个临界点是<b>瞄具倍率本身</b>，换把枪就换个位置 ——
+        // 玩家实测「超过 3.0 就没有放大了」正是撞上了这条（那把镜正好 3×）。
+        // 于是整个 3.0~8.0 区间是一段行为完全相同、且功能已被关掉的死区。
+        //
+        // 改成按比例分配就没有这个问题：倍率是<b>相乘</b>的，
+        //     世界 W = Z^share，镜内 P = Z/W = Z^(1-share)
+        // share 在 [0,1] 上每一点都有意义、且与瞄具倍率无关：
+        //     share=0   → W=1、P=Z      纯 PIP（镜外 1×，最软）
+        //     share=0.5 → W=P=√Z        对半分，镜内真实像素 √Z 倍
+        //     share=1   → W=Z、P=1      整屏变焦（最锐，等于关掉 PIP）
+        // 两端都是已知行为，中间连续，没有死区，换任何倍率的镜表现都一致。
+        return (float) Math.pow(zoom, share);
+    }
+
+    /**
+     * 当前这一帧世界实际放大了多少 —— 与 {@code CameraSetupEvent} 里那条
+     * {@code 1 + (zoom-1)·progress} 完全同式，两边必须逐帧一致，否则镜内外会打架。
+     */
+    public static float worldZoomAtProgress(float aimingProgress) {
+        return 1.0f + (worldZoomTarget() - 1.0f) * Mth.clamp(aimingProgress, 0.0f, 1.0f);
+    }
+
+    /** 供 {@code CameraSetupEvent} 使用：PIP 生效时世界该放大多少。 */
+    public static float currentWorldZoom() {
+        return worldZoomAtProgress(currentAimingProgress());
+    }
+
+    private static float currentAimingProgress() {
+        Minecraft mc = Minecraft.getInstance();
+        LocalPlayer player = mc.player;
+        if (player == null) {
+            return 0.0f;
+        }
+        return Mth.clamp(IClientPlayerGunOperator.fromLocalPlayer(player)
+                .getClientAimingProgress(mc.getDeltaTracker().getGameTimeDeltaPartialTick(false)), 0.0f, 1.0f);
+    }
+
+    // ------------------------------------------------------------------
+    // 抓取本帧的世界画面
+    // ------------------------------------------------------------------
+
+    /**
+     * 把刚画完的世界拷进离屏纹理，留给稍后的合成阶段重采样。
+     *
+     * <h3>为什么必须卡在这一刻</h3>
+     * 由 {@code GameRendererMixin} 注入在 {@code renderLevel} 里
+     * {@code LevelRenderer#render} 那次调用<b>之后</b>：
+     * <ul>
+     *   <li>再早 → 世界还没画完；</li>
+     *   <li>再晚（越过 {@code renderItemInHand}）→ 拷贝里会混进枪和手，
+     *       镜片里就会出现一把缩小的枪。</li>
+     * </ul>
+     * 这个位置正好是「世界已完成、视模尚未开始」的唯一窗口
+     * （renderLevel 偏移 405 之后、502 的 renderItemInHand 之前）。
+     *
+     * <p>已知的小缺口：发光实体描边由 {@code levelRenderer.doEntityOutline()}
+     * 在 {@code renderLevel} 返回<b>之后</b>才贴到主画面（GameRenderer 偏移 275），
+     * 所以镜内看不到那圈描边。属可接受的观感差异，不影响正确性。
+     */
+    public static void captureScene(Minecraft mc) {
+        if (failed || rerenderMode()) {
+            // 二次渲染模式下镜内画面由 renderScopeView 产出，不走拷贝。
+            return;
+        }
+        // 光影下这个注入点的含义不同：Iris 把手部渲染搬进了 LevelRenderer#render 内部，
+        // 于是「LevelRenderer#render 之后」= 整条 Iris 管线（延迟光照、composite、
+        // 色调映射、手部）<b>全部跑完</b>之后 —— 抓到的正是最终画面。
+        // 合成随后由 compositeAfterLevelUnderShaders() 在同一处完成。
+        if (!isEnabledForHeldGun() || currentAimingProgress() <= minAimingProgress()) {
+            sceneCaptured = false;
+            return;
+        }
+        try {
+            RenderTarget main = mc.gameRenderer.mainRenderTarget();
+            if (main == null) {
+                sceneCaptured = false;
+                return;
+            }
+            GpuTexture source = main.getColorTexture();
+            if (source == null || source.isClosed()) {
+                sceneCaptured = false;
+                return;
+            }
+            int w = source.getWidth(0);
+            int h = source.getHeight(0);
+            // 格式取自源纹理本身：copyTextureToTexture 要求两端一致，
+            // 而主 target 的格式并不保证永远是 RGBA8_UNORM（取决于 MainTarget 的构造）。
+            TextureTarget copy = ScopePipTarget.getOrCreate(w, h, source.getFormat(), false);
+            if (copy == null) {
+                failed = true;
+                sceneCaptured = false;
+                return;
+            }
+            // 逐像素拷贝。两张纹理都是 RenderTarget#createBuffers 建的，
+            // usage 位是 15 = COPY_DST|COPY_SRC|TEXTURE_BINDING|RENDER_ATTACHMENT
+            //（字节码 bipush 15 实读），拷贝所需的两个位都在。
+            //
+            // 参数顺序照 CommandEncoder#copyTextureToTexture 的边界检查反推：
+            //   (src, dst, mipLevel, dstX, dstY, srcX, srcY, width, height)
+            CommandEncoder encoder = RenderSystem.getDevice().createCommandEncoder();
+            encoder.copyTextureToTexture(source, copy.getColorTexture(), 0, 0, 0, 0, 0, w, h);
+            sceneCaptured = true;
+            if (!loggedFirstCapture) {
+                loggedFirstCapture = true;
+                GunMod.LOGGER.info("[TACZ Scope] Scope PIP active: reprojecting a {}x{} scene copy at {}x magnification.",
+                        w, h, scopeMagnification());
+            }
+        } catch (Exception e) {
+            failed = true;
+            sceneCaptured = false;
+            GunMod.LOGGER.error("[TACZ Scope] Scope PIP scene capture failed; PIP disabled, "
+                    + "falling back to whole-screen FOV zoom.", e);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // 二次渲染（ScopePipRerender = true）
+    // ------------------------------------------------------------------
+
+    /**
+     * 【二次渲染模式】用窄 FOV 把世界再画一遍到离屏 target，得到<b>原生分辨率</b>的镜内画面。
+     *
+     * <p>由 {@code GameRendererMixin} 注入在 {@code renderLevel} 里
+     * {@code LevelRenderer#render} 那次调用<b>之前</b> —— 让 vanilla 那一遍收尾，
+     * 覆盖掉我们可能污染到的共享状态（{@code entityOutlineTarget}、区块编译调度等）。
+     *
+     * <h2>与重投影模式的取舍</h2>
+     * 重投影的镜内分辨率上限是「屏幕分辨率 ÷ 倍率」，8 倍镜下惨不忍睹。
+     * 这条路的镜内像素是<b>真画出来的</b>，没有那个上限；代价是每帧多跑一遍世界渲染。
+     *
+     * <h2>两处必须同时改的投影</h2>
+     * <ol>
+     *   <li>{@code RenderSystem.setProjectionMatrix(...)} —— 原版路径（实体、粒子、天空）看这个；</li>
+     *   <li>{@link SodiumCompat#overrideProjection} —— <b>Sodium 的地形只看它自己的快照</b>。
+     *       第一版漏了这条，结果地形用宽 FOV、实体用窄 FOV，镜内两套比例糊在一起。</li>
+     * </ol>
+     */
+    public static void renderScopeView(Minecraft mc,
+                                       GraphicsResourceAllocator allocator,
+                                       FogRenderer fogRenderer,
+                                       GameRenderState gameRenderState,
+                                       DeltaTracker deltaTracker) {
+        if (failed || !rerenderMode()) {
+            return;
+        }
+        if (redirectTarget != null) {
+            // 理论不可达（我们调的是 levelRenderer.render，不是 renderLevel），
+            // 但重入一次就会把离屏 target 画花且极难定位。
+            return;
+        }
+        if (!isEnabledForHeldGun() || currentAimingProgress() <= minAimingProgress()) {
+            sceneCaptured = false;
+            return;
+        }
+        CameraRenderState camera = gameRenderState.levelRenderState.cameraRenderState;
+        if (camera == null || !camera.initialized || camera.isPanoramicMode) {
+            sceneCaptured = false;
+            return;
+        }
+        RenderTarget main = mc.gameRenderer.mainRenderTarget();
+        if (main == null || main.width <= 0 || main.height <= 0) {
+            sceneCaptured = false;
+            return;
+        }
+        GpuTexture mainColor = main.getColorTexture();
+        if (mainColor == null || mainColor.isClosed()) {
+            sceneCaptured = false;
+            return;
+        }
+        TextureTarget pip = ScopePipTarget.getOrCreate(main.width, main.height, mainColor.getFormat(), true);
+        if (pip == null) {
+            failed = true;
+            sceneCaptured = false;
+            return;
+        }
+
+        // 存档。刻意不用 RenderSystem.backupProjectionMatrix()：那对 save/restore 共用
+        // 一个静态槽位，若二次渲染内部（后处理链等）也用了它，我们的还原就会拿到别人的值。
+        GpuBufferSlice savedProjection = RenderSystem.getProjectionMatrixBuffer();
+        ProjectionType savedProjectionType = RenderSystem.getProjectionType();
+        boolean sodiumPatched = false;
+        try {
+            if (!buildNarrowProjection(camera, pip)) {
+                sceneCaptured = false;
+                return;
+            }
+            RenderSystem.setProjectionMatrix(projectionBuffer.getBuffer(PROJECTION), ProjectionType.PERSPECTIVE);
+            sodiumPatched = SodiumCompat.overrideProjection(NARROW_MATRIX);
+
+            boolean renderSky = !mc.gui.hud.getBossOverlay().shouldCreateWorldFog();
+            ScopePipTrace.mark("SCOPE-PASS BEGIN (redirect active)");
+            redirectTarget = pip;
+            try {
+                mc.levelRenderer.render(
+                        allocator,
+                        deltaTracker,
+                        // 方块高亮线框：镜内不画，屏幕空间的描边在镜内没有意义。
+                        false,
+                        camera,
+                        camera.viewRotationMatrix,
+                        fogRenderer.getBuffer(FogRenderer.FogMode.WORLD),
+                        camera.fogData.color,
+                        renderSky);
+            } finally {
+                redirectTarget = null;
+                ScopePipTrace.mark("SCOPE-PASS END (redirect cleared)");
+            }
+            sceneCaptured = true;
+            if (!loggedFirstCapture) {
+                loggedFirstCapture = true;
+                GunMod.LOGGER.info("[TACZ Scope] Scope PIP second-render pass active: {}x{} at {}x "
+                                + "(sodium terrain projection synced: {}).",
+                        pip.width, pip.height, scopeMagnification(), sodiumPatched);
+            }
+        } catch (Exception e) {
+            failed = true;
+            sceneCaptured = false;
+            GunMod.LOGGER.error("[TACZ Scope] Scope PIP second-render pass failed; PIP disabled, "
+                    + "falling back to whole-screen FOV zoom.", e);
+        } finally {
+            if (sodiumPatched) {
+                SodiumCompat.restoreProjection();
+            }
+            // 【关键】把 Sodium「本帧区块 uniform 已上传」的闸重新打开。
+            //
+            // 不做这一步，紧随其后的 vanilla 那一遍调 update() 会被早退挡掉，
+            // 主画面的地形就继续用我们刚上传的【窄投影】绘制 —— 表现为近处的水、
+            // 冰柱被拉伸放大，而远处走 Voxy LOD 的地形正常。这正是长期被误判为
+            // 「镜内画面溢出到镜外」的那个症状的真正成因。详见 SodiumCompat 的说明。
+            //
+            // 放在 finally 里：哪怕镜内那一遍中途抛了异常，也绝不能把主画面留在错误的投影上。
+            SodiumCompat.resetChunkUniformUpload();
+            RenderSystem.setProjectionMatrix(savedProjection, savedProjectionType);
+        }
+    }
+
+    /**
+     * 按瞄具倍率算出镜内那一遍的透视投影，写进 {@link #PROJECTION} 与 {@link #NARROW_MATRIX}。
+     *
+     * <h3>基准 FOV 从投影矩阵反解，而不是读 {@code options.fov()}</h3>
+     * 当帧的世界 FOV 还叠着疾跑/药水/{@code fovEffectScale} 与我们自己的平滑。
+     * 而透视矩阵的 {@code m11 = 1 / tan(fovY / 2)} 是恒等式，与纵横比、近远平面都无关，
+     * 反解出来的就是 vanilla 本帧真正用的那个 FOV。
+     */
+    private static boolean buildNarrowProjection(CameraRenderState camera, TextureTarget pip) {
+        float m11 = camera.projectionMatrix.m11();
+        if (!Float.isFinite(m11) || m11 <= 1.0e-4f) {
+            return false;
+        }
+        double baseFov = Math.toDegrees(2.0 * Math.atan(1.0 / m11));
+        double pipFov = MathUtil.magnificationToFov(scopeMagnification(), baseFov);
+        if (!Double.isFinite(pipFov) || pipFov <= 0.0) {
+            return false;
+        }
+        // 近/远平面与 vanilla 相机逐值一致（Camera#update 偏移 160-175）。
+        PROJECTION.setupPerspective(0.05f, camera.depthFar, (float) pipFov, pip.width, pip.height);
+        PROJECTION.getMatrix(NARROW_MATRIX);
+        if (projectionBuffer == null) {
+            projectionBuffer = new ProjectionMatrixBuffer("tacz scope pip");
+        }
+        return true;
+    }
+
+    // ------------------------------------------------------------------
+    // 合成
+    // ------------------------------------------------------------------
+
+    /**
+     * 在阶段边界把放大后的世界贴进目镜孔径。
+     *
+     * <p>调用点在 {@code FeatureRenderDispatcherMixin}，紧跟
+     * {@link ScopeMaskRenderer#renderAtPhaseBoundary()} 之后 —— 见类注释里的顺序论证。
+     */
+    public static void compositeAtPhaseBoundary() {
+        if (failed || !sceneCaptured) {
+            return;
+        }
+        if (irisOwnsLens()) {
+            // 见 captureScene：光影下这条路整条让开，镜片只能有一个主人。
+            return;
+        }
+        // 【诊断】只跑镜内那一遍、不合成。见 ScopePipDebugNoComposite 的说明。
+        if (RenderConfig.SCOPE_PIP_DEBUG_NO_COMPOSITE != null
+                && RenderConfig.SCOPE_PIP_DEBUG_NO_COMPOSITE.get()) {
+            return;
+        }
+        if (!ScopeMaskRenderer.isInHandPass()) {
+            return;
+        }
+        // 每帧只合成一次。Iris 的 HandRenderer 一帧跑两次手部 pass，
+        // 第二次再合成会把 solid 阶段已经画进孔径的东西（蚀刻准星等）整片盖掉。
+        if (!ScopeMaskRenderer.claimCompositeSlot()) {
+            return;
+        }
+        // 注意：isEnabledForHeldGun 里那道掩码判据，在这个调用点读到的是【本帧】的值
+        //（掩码刚在上一句 renderAtPhaseBoundary 里画完），而在
+        // suppressesWorldFovZoom / captureScene 那两个调用点读到的是上一帧的 ——
+        // 同一个字段、不同时刻，这正是设计里说的那一帧延迟。
+        if (!isEnabledForHeldGun()) {
+            return;
+        }
+        // 二次渲染模式下离屏纹理【已经】是窄 FOV 画出来的，屏幕坐标与主画面一一对应，
+        // 再做一次重投影就等于放大两遍。倍率传 1 = 直接逐像素取用。
+        //
+        // 重投影模式要除掉世界已经放大的那一份：世界放大 W 之后，主画面里的物体本来就大了
+        // W 倍，镜内只需再补 Z/W 就够。不除的话总倍率会变成 W×Z（镜内外对不上）。
+        runComposite(rerenderMode()
+                ? 1.0f
+                : Math.max(1.0f, scopeMagnification()) / worldZoomAtProgress(currentAimingProgress()));
+    }
+
+    /**
+     * 【光影路径 · 屏幕空间】Iris 整条管线跑完之后，直接在<b>最终画面</b>上做镜内放大。
+     *
+     * <h2>为什么这条路比「在 pack 的着色器里采样 colortex」可靠得多</h2>
+     * 那条路要求我们猜中「已着色的场景此刻躺在哪张 colortex 里」，而这个答案
+     * <b>逐 pack 不同</b>（Eclipse 是 colortex2，别家可能是 0/3/…），
+     * 还要考虑乒乓翻转、缓冲被后续 pass 覆盖等等 —— 每一条都是一次盲猜。
+     * 这里读的是 Iris <b>已经完工</b>的那张图：光照、体积雾、色调映射全部就位，
+     * 与镜外像素<b>逐字节同源</b>，因此镜内外的色调天然一致，也不存在任何 pack 依赖。
+     *
+     * <h2>镜内为什么不会出现一把缩小的枪</h2>
+     * 这是这条路能成立的关键。镜身在孔径内是 {@code discard} 的（模式 1），
+     * 所以最终画面里<b>孔径那块就是 1× 的世界</b>，没有枪。
+     * 而重投影采样点是 {@code center + (uv-center)/Z}：{@code uv} 取遍孔径时，
+     * 采样点只覆盖以中心为原点、半径缩小到 {@code 1/Z} 的一小块 ——
+     * 那块<b>整个落在孔径内部</b>，于是采到的全都是干净的世界像素。
+     * （无光影路径必须在 {@code renderItemInHand} 之前抓图，正是因为它没有这个性质。）
+     *
+     * <h2>代价</h2>
+     * 镜内实际只由孔径内 {@code 1/Z} 那一小块像素放大而来，高倍镜下会明显变软 ——
+     * 与重投影模式同一个上限（见 IMPLEMENTATION 文档 §3）。
+     * 换来的是「一定出图、颜色一定对、不依赖任何 pack 约定」。
+     */
+    public static void compositeAfterLevelUnderShaders() {
+        if (failed || !sceneCaptured || !irisOwnsLens()) {
+            return;
+        }
+        if (RenderConfig.SCOPE_PIP_DEBUG_NO_COMPOSITE != null
+                && RenderConfig.SCOPE_PIP_DEBUG_NO_COMPOSITE.get()) {
+            return;
+        }
+        // 每帧一次。这里不看 isInHandPass —— 调用点在手部 pass 之外（整条管线之后）。
+        if (!ScopeMaskRenderer.claimCompositeSlot()) {
+            return;
+        }
+        if (!isEnabledForHeldGun()) {
+            return;
+        }
+        // 【倍率跟着开镜进度走】这条路的素材是最终画面，画面里是有枪的 ——
+        // 干净的世界像素只存在于孔径那一块。抬镜过程中瞄具还没移到屏幕中心，
+        // 而重投影的采样点恒定绕屏幕中心收缩，此时那块可能还压在枪身上，
+        // 直接给满倍率会让镜内闪过一段放大的枪。
+        //
+        // 用 1 + (Z-1)·progress：progress→0 时倍率→1，采样点 == 当前像素本身，
+        // 于是「合成结果 == 底下已经画好的 1× 画面」，肉眼零变化；
+        // 瞄具归位（progress→1）时才到满倍率。顺带与整屏变焦那条老路的公式一致
+        // （CameraSetupEvent 的 1 + (zoom-1)·progress），过渡手感也对得上。
+        float progress = currentAimingProgress();
+        float zoom = Math.max(1.0f, scopeMagnification());
+        // 总倍率按进度插值，再除掉世界这一帧已经放大的那一份，剩下的才归镜内。
+        // 两者相乘恒等于 1+(Z-1)·progress，所以镜内外任何时刻都是同一个总倍率。
+        runComposite((1.0f + (zoom - 1.0f) * progress) / worldZoomAtProgress(progress));
+    }
+
+    /** 合成本体：读离屏拷贝、按倍率重投影、只写进目镜孔径。两个调用点共用。 */
+    private static void runComposite(float magnification) {
+        TextureTarget scene = ScopePipTarget.current();
+        RenderTarget mask = ScopeMaskTarget.current();
+        if (scene == null || mask == null) {
+            return;
+        }
+        Minecraft mc = Minecraft.getInstance();
+        RenderTarget main = mc.gameRenderer.mainRenderTarget();
+        if (main == null) {
+            return;
+        }
+        try {
+            CommandEncoder encoder = RenderSystem.getDevice().createCommandEncoder();
+            // 不挂深度附件：合成不测试也不写深度（见 compositePipeline 的注释）。
+            // Optional.empty() = 不清空，保留主 target 已有的画面。
+            //
+            // 注意这里【读】的是 scene 那张拷贝、【写】的是主 target ——
+            // 两者是不同的纹理。若省掉拷贝直接采样主 target，就成了同一个 pass 里
+            // 又读又写同一张纹理，那是未定义行为。拷贝那一步存在的全部意义就在这里。
+            try (RenderPass pass = encoder.createRenderPass(
+                    () -> "tacz_scope_pip_composite",
+                    main.getColorTextureView(),
+                    Optional.empty())) {
+                pass.setPipeline(compositePipeline());
+                // 【硬件剪裁 —— 越界的最后一道闸】
+                //
+                // 着色器里的「掩码为假就 discard」是【软】约束：掩码纹理一旦有任何问题
+                //（没绑上、内容不对、采样错位），discard 不触发，这张放大的世界就会被
+                // 整屏糊上去 —— 用户实测的「放大画面溢出到镜外」正是这个形态。
+                //
+                // 而目镜在屏幕上的包围盒是掩码阶段本来就算得出来的。用它开 scissor，
+                // 合成在物理上就不可能画到镜片之外：掩码继续负责镜片内部的精确形状，
+                // scissor 负责「绝不越界」。两道约束一软一硬，一道失效还有另一道。
+                applyLensScissor(pass, main);
+                // Globals（ScreenSize）由它提供，收缩带的纵横比修正要用。
+                RenderSystem.bindDefaultUniforms(pass);
+                // 倍率与锐化强度经 ColorModulator 的 r/g 送进着色器。
+                // bindDefaultUniforms 不管 DynamicTransforms 这个块，
+                // 得自己写 —— 与 ScopeMaskRenderer 同一套路。
+                pass.setUniform("DynamicTransforms",
+                        RenderSystem.getDynamicUniforms().writeTransform(
+                                new Matrix4f(),
+                                new Vector4f(magnification, sharpness(), paintLensFlag(), 1.0f)));
+                // 场景拷贝：LINEAR。着色器里的 Catmull-Rom 重建正是用一组
+                // 硬件双线性抽头拼出来的，所以这里必须是 LINEAR 而非 NEAREST。
+                pass.bindTexture("InSampler", scene.getColorTextureView(),
+                        RenderSystem.getSamplerCache().getClampToEdge(FilterMode.LINEAR));
+                // 掩码：NEAREST。二值数据，线性过滤会在边缘产生 0.5 附近的中间值，
+                // 让 `> 0.5` 判定抖动成一圈毛边 —— 与 ScopeMaskTextureHandle 同一理由。
+                pass.bindTexture(MASK_SAMPLER, mask.getColorTextureView(),
+                        RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
+                // 无顶点缓冲的全屏三角形：core/screenquad.vsh 用 gl_VertexID 造顶点。
+                // 参数顺序照 RenderTarget#blitAndBlendToTexture 抄：draw(3, 1, 0, 0)。
+                pass.draw(3, 1, 0, 0);
+            }
+        } catch (Exception e) {
+            failed = true;
+            GunMod.LOGGER.error("[TACZ Scope] Scope PIP composite failed; PIP disabled, "
+                    + "falling back to whole-screen FOV zoom.", e);
+        }
+    }
+
+    /**
+     * 把合成限制在目镜的屏幕包围盒内。
+     *
+     * <p>包围盒来自 {@link ScopeMaskRenderer#maskBoundsNdc()}，与掩码同一坐标系、同一帧算出。
+     * 拿不到包围盒（读投影 UBO 失败等）就不开剪裁，退回纯掩码约束 —— 即旧行为，不会更糟。
+     *
+     * <p>四周各留 2 像素余量：掩码的边缘羽化与 NDC→像素的取整都可能差一两个像素，
+     * 剪裁若卡得比掩码还紧，镜片边缘会被削掉一圈。
+     */
+    private static void applyLensScissor(RenderPass pass, RenderTarget target) {
+        if (!ScopeMaskRenderer.hasMaskBounds()) {
+            return;
+        }
+        float[] b = ScopeMaskRenderer.maskBoundsNdc();
+        int w = target.width;
+        int h = target.height;
+        // NDC[-1,1] → 像素。scissor 的原点在左下，与 NDC 的 y 方向一致，不需要翻转。
+        int x0 = (int) Math.floor((b[0] * 0.5f + 0.5f) * w) - 2;
+        int y0 = (int) Math.floor((b[1] * 0.5f + 0.5f) * h) - 2;
+        int x1 = (int) Math.ceil((b[2] * 0.5f + 0.5f) * w) + 2;
+        int y1 = (int) Math.ceil((b[3] * 0.5f + 0.5f) * h) + 2;
+        x0 = Mth.clamp(x0, 0, w);
+        y0 = Mth.clamp(y0, 0, h);
+        x1 = Mth.clamp(x1, 0, w);
+        y1 = Mth.clamp(y1, 0, h);
+        if (x1 <= x0 || y1 <= y0) {
+            return;
+        }
+        pass.enableScissor(x0, y0, x1 - x0, y1 - y0);
+    }
+
+    // ------------------------------------------------------------------
+    // 配置读取（配置可能尚未加载，一律带 null 兜底）
+    // ------------------------------------------------------------------
+
+    private static float minAimingProgress() {
+        return RenderConfig.SCOPE_PIP_MIN_AIMING_PROGRESS == null
+                ? 0.05f : RenderConfig.SCOPE_PIP_MIN_AIMING_PROGRESS.get().floatValue();
+    }
+
+    private static float sharpness() {
+        return RenderConfig.SCOPE_PIP_SHARPNESS == null
+                ? 0.5f : RenderConfig.SCOPE_PIP_SHARPNESS.get().floatValue();
+    }
+
+    /**
+     * 合成着色器的诊断标志：0 = 把覆盖区涂成品红，1 = 正常出图。
+     * 走 {@code ColorModulator.b}，那个通道本来就是常量 1.0 的空闲载体。
+     */
+    private static float paintLensFlag() {
+        boolean paint = RenderConfig.SCOPE_PIP_DEBUG_PAINT_LENS != null
+                && RenderConfig.SCOPE_PIP_DEBUG_PAINT_LENS.get();
+        return paint ? 0.0f : 1.0f;
+    }
+
+    /**
+     * 光影开着时，镜片归 Iris 那条 shader 注入路（模式 3）管，本类的
+     * 「拷贝主画面 + 全屏重投影」通道必须整条让开。
+     *
+     * <h3>为什么必须互斥</h3>
+     * 两条路都想往孔径里落笔。同时跑的话，重投影那趟会用 vanilla 管线把一张
+     * <b>未经光影着色</b>的拷贝糊进镜片，正好覆盖掉 shader 注入刚写对的颜色 ——
+     * 表现为「镜内偏灰/发暗、或与镜外色调对不上」。而且它本来就跑不通：
+     * 光影管线下这趟绘制的写入会被下游丢弃（历史上试过，见 docs §2.4）。
+     *
+     * <p>顺带省掉一次每帧的全屏 {@code copyTextureToTexture}。</p>
+     */
+    private static boolean irisOwnsLens() {
+        return IrisCompat.isUsingRenderPack();
+    }
+
+    private static boolean allowShaderPacks() {
+        return RenderConfig.SCOPE_PIP_ALLOW_SHADER_PACKS != null
+                && RenderConfig.SCOPE_PIP_ALLOW_SHADER_PACKS.get();
+    }
+}

--- a/src/main/java/com/tacz/guns/client/render/scope/ScopePipTarget.java
+++ b/src/main/java/com/tacz/guns/client/render/scope/ScopePipTarget.java
@@ -1,0 +1,121 @@
+package com.tacz.guns.client.render.scope;
+
+import com.mojang.blaze3d.GpuFormat;
+import com.mojang.blaze3d.pipeline.TextureTarget;
+import com.tacz.guns.GunMod;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * 「镜内画中画」用的离屏纹理 —— 本帧世界画面的一份<b>拷贝</b>。
+ *
+ * <h2>它为什么只是一份拷贝</h2>
+ * 镜内画面 = 同一台摄像机、同一个朝向、只是 FOV 更窄的那一张图。
+ * 而透视投影下「压窄 FOV」在屏幕空间就是<b>绕光轴的等比放大</b>：
+ * <pre>
+ * 窄FOV下某点的 NDC = 宽FOV下同一点的 NDC × Z          （Z = 倍率）
+ *   ⇒ 反过来采样：wideUV = center + (narrowUV − center) / Z
+ * </pre>
+ * 这个关系是<b>恒等的</b>，不含任何近似 —— 于是根本不需要把世界再画一遍，
+ * 把已经画好的世界拷出来、按上式重采样即可。
+ *
+ * <h2>为什么不是「再渲染一遍世界」</h2>
+ * 第一版确实那么做（重定向 {@code GameRenderer#mainRenderTarget()} 后再跑一次
+ * {@code LevelRenderer#render}）。它在纯原版渲染下成立，但**与 Sodium 不兼容**：
+ * Sodium 完全接管地形渲染，不走
+ * {@code ChunkSectionLayerGroup#outputTarget() → gameRenderer.mainRenderTarget()}
+ * 这条路，于是重定向对地形无效。实测症状正是：
+ * 镜内只有原版路径的实体/粒子/天空被放大、地形没有（「画面糊在一起」），
+ * 同时一帧内两次驱动 {@code LevelRenderer#render} 打乱了 Sodium 与
+ * ImmediatelyFast 的逐帧状态，导致<b>镜外</b>的实体也一并消失。
+ *
+ * <p>拷贝方案没有这个问题：它只读<b>最终的颜色缓冲</b>，
+ * 至于那些像素是 Sodium 画的还是原版画的，完全无所谓。
+ *
+ * <h2>尺寸与格式：与主帧缓冲严格一致</h2>
+ * 拷贝是逐像素的 {@code copyTextureToTexture}，源和目标必须同格式；
+ * 尺寸也取满，<b>不做任何降采样</b> —— 镜内画面本来就要放大一个中心裁切区，
+ * 源头再降分辨率只会雪上加霜，而一次全屏拷贝的开销与「多渲一遍世界」不在一个量级，
+ * 没有省的必要。
+ *
+ * <p>不需要深度附件：这里存的是一张已完成的二维图像，不参与任何深度测试。
+ */
+@Environment(EnvType.CLIENT)
+public final class ScopePipTarget {
+
+    @Nullable
+    private static TextureTarget target;
+    private static int lastWidth = -1;
+    private static int lastHeight = -1;
+    @Nullable
+    private static GpuFormat lastFormat = null;
+    private static boolean lastUseDepth = false;
+
+    /** 一旦出过错就永久停用，避免每帧刷屏或反复抛异常。 */
+    private static boolean failed = false;
+
+    private ScopePipTarget() {
+    }
+
+    /**
+     * 取（必要时创建/重建）镜内画面的离屏纹理。
+     *
+     * @param width  主帧缓冲宽度（物理像素）
+     * @param height 主帧缓冲高度（物理像素）
+     * @param format 主帧缓冲颜色纹理的格式；拷贝要求两端一致，所以由调用方传进来
+     * @return 可用的 target；失败时返回 {@code null}（调用方据此退回不做 PIP）
+     */
+    @Nullable
+    public static TextureTarget getOrCreate(int width, int height, GpuFormat format, boolean needsDepth) {
+        if (failed) {
+            return null;
+        }
+        int w = Math.max(1, width);
+        int h = Math.max(1, height);
+        try {
+            if (target == null || w != lastWidth || h != lastHeight || format != lastFormat
+                    || needsDepth != lastUseDepth) {
+                if (target != null) {
+                    target.destroyBuffers();
+                    target = null;
+                }
+                // 重投影模式存的是一张已完成的二维图像，不需要深度；
+                // 二次渲染模式跑的是完整的世界渲染，没有深度附件就没有遮挡关系。
+                target = new TextureTarget("tacz_scope_pip", w, h, needsDepth, format);
+                lastWidth = w;
+                lastHeight = h;
+                lastFormat = format;
+                lastUseDepth = needsDepth;
+                GunMod.LOGGER.info("[TACZ Scope] Scope PIP target allocated at {}x{} ({}, depth={}).",
+                        w, h, format, needsDepth);
+            }
+            return target;
+        } catch (Exception e) {
+            failed = true;
+            GunMod.LOGGER.error("[TACZ Scope] Failed to allocate the scope PIP scene copy; PIP disabled.", e);
+            close();
+            return null;
+        }
+    }
+
+    @Nullable
+    public static TextureTarget current() {
+        return failed ? null : target;
+    }
+
+    public static void close() {
+        if (target != null) {
+            try {
+                target.destroyBuffers();
+            } catch (Exception ignored) {
+                // 关闭失败没有补救手段，忽略即可
+            }
+            target = null;
+        }
+        lastWidth = -1;
+        lastHeight = -1;
+        lastFormat = null;
+        lastUseDepth = false;
+    }
+}

--- a/src/main/java/com/tacz/guns/client/render/scope/ScopePipTrace.java
+++ b/src/main/java/com/tacz/guns/client/render/scope/ScopePipTrace.java
@@ -1,0 +1,155 @@
+package com.tacz.guns.client.render.scope;
+
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.tacz.guns.GunMod;
+import com.tacz.guns.config.client.RenderConfig;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 【诊断】把「镜内二次渲染」那一帧的渲染目标解析过程原样打出来。
+ *
+ * <h2>为什么需要它</h2>
+ * 「放大画面溢出到镜外」这个症状，靠静态分析已经连错四次：
+ * 先怪 Sodium 绕开 {@code mainRenderTarget()}（错，它走），
+ * 再怪 ImmediatelyFast 缓存帧缓冲（错，它只是跳过绑 0），
+ * 再怪 SkyRenderer 缓存 target（是真 bug，但会被 vanilla 的 clear 抹掉，解释不了溢出），
+ * 再怪 Voxy 是第三个地形渲染器（错，它的 target 与投影都取自被我们接管的两处）。
+ *
+ * <p>共同的失败模式是：<b>症状对得上就当成因果</b>。
+ * 而这个问题的关键事实其实只有两条，都可以直接测出来，不必猜：
+ * <ol>
+ *   <li>镜内那一遍进行期间，有没有<b>谁解析到了真正的主 target</b>（= 漏出去的那一笔）；</li>
+ *   <li>vanilla 的 clear 之后，还有没有人拿着我们的窄投影在画
+ *       （= 延迟提交，重定向再对也没用）。</li>
+ * </ol>
+ *
+ * <h2>怎么测</h2>
+ * {@code GameRenderer#mainRenderTarget()} 的注入点本来就是<b>所有</b>目标解析的必经之路
+ * （Sodium 的 {@code TerrainRenderPass}、Voxy 经由它、vanilla 的 clear lambda、帧图导入……
+ * 全都从这里过）。在那里记一行「谁问的 + 给了哪个」，再配上镜内那一遍的进出标记，
+ * 一帧的完整顺序就出来了。
+ *
+ * <p>只在 {@code ScopePipDebugTrace} 打开时工作，且<b>只记录有限几帧</b> ——
+ * 这条路径每帧被调用几十次，不封顶会瞬间把日志淹掉。
+ */
+@Environment(EnvType.CLIENT)
+public final class ScopePipTrace {
+
+    /** 最多记录几帧。够看清一帧的完整顺序，又不会把日志刷爆。 */
+    private static final int FRAME_BUDGET = 3;
+    /** 单帧内最多记录多少行，防御性上限（正常一帧几十行）。 */
+    private static final int LINES_PER_FRAME = 400;
+
+    private static int framesTraced = 0;
+    private static int linesThisFrame = 0;
+    private static boolean tracingThisFrame = false;
+    private static boolean announced = false;
+
+    /**
+     * 本帧的行缓冲。
+     *
+     * <h3>为什么要缓冲，而不是边走边打</h3>
+     * 第一版直接打，结果三帧预算<b>在标题画面上就烧光了</b> ——
+     * 那几帧里解析 target 的是 {@code CubeMap#render} 和 {@code GuiRenderer#render}，
+     * 与瞄具毫无关系，等玩家真进世界举枪时已经没有预算了，日志里一片空白。
+     *
+     * <p>改成先缓冲、<b>只有当这一帧确实跑了镜内那一遍</b>才落盘并计入预算。
+     * 于是三帧预算一定花在有意义的帧上。
+     */
+    private static final List<String> BUFFER = new ArrayList<>();
+    /** 本帧是否真的跑了镜内那一遍（缓冲要不要落盘就看它）。 */
+    private static boolean sawScopePass = false;
+
+    private ScopePipTrace() {
+    }
+
+    public static boolean enabled() {
+        return RenderConfig.SCOPE_PIP_DEBUG_TRACE != null
+                && RenderConfig.SCOPE_PIP_DEBUG_TRACE.get()
+                && framesTraced < FRAME_BUDGET;
+    }
+
+    /**
+     * 每帧开头调用（接在瞄具帧状态归零那一处）：结算上一帧，再开一帧的缓冲。
+     *
+     * <p>结算规则就是本类存在的理由 —— <b>只有跑过镜内那一遍的帧才落盘、才计入预算</b>。
+     * 没跑的帧（标题画面、没举枪、没开镜）整份丢弃，一行都不打。
+     */
+    public static void beginFrame() {
+        if (tracingThisFrame && sawScopePass && !BUFFER.isEmpty()) {
+            framesTraced++;
+            GunMod.LOGGER.info("[TACZ Scope][trace] ---- frame with scope pass ({}/{}) ----",
+                    framesTraced, FRAME_BUDGET);
+            for (String line : BUFFER) {
+                GunMod.LOGGER.info("[TACZ Scope][trace] {}", line);
+            }
+            GunMod.LOGGER.info("[TACZ Scope][trace] ---- end frame ----");
+        }
+        BUFFER.clear();
+        sawScopePass = false;
+        linesThisFrame = 0;
+        tracingThisFrame = enabled();
+        if (tracingThisFrame && !announced) {
+            announced = true;
+            GunMod.LOGGER.info("[TACZ Scope][trace] Armed: will capture {} frames that actually run the "
+                    + "scope pass. Any 'MAIN' between SCOPE-PASS BEGIN and END is the leak; its stack "
+                    + "trace names the culprit.", FRAME_BUDGET);
+        }
+    }
+
+    /** 记一个阶段标记（镜内那一遍的进出、合成等）。 */
+    public static void mark(String what) {
+        if (!tracingThisFrame) {
+            return;
+        }
+        if (what.startsWith("SCOPE-PASS BEGIN")) {
+            // 这一帧值得记 —— 结算时才会落盘。
+            sawScopePass = true;
+        }
+        if (linesThisFrame++ > LINES_PER_FRAME) {
+            return;
+        }
+        BUFFER.add("== " + what);
+    }
+
+    /**
+     * 记一次 {@code mainRenderTarget()} 解析。
+     *
+     * @param resolved   实际返回的 target
+     * @param redirected 是否被我们顶替成了离屏 target
+     */
+    public static void targetResolved(@Nullable RenderTarget resolved, boolean redirected) {
+        if (!tracingThisFrame || linesThisFrame++ > LINES_PER_FRAME) {
+            return;
+        }
+        BUFFER.add((redirected ? "SCOPE <- " : "MAIN  <- ") + caller());
+    }
+
+    /**
+     * 谁问的。跳过 JDK / 本类 / mixin 胶水，取最上面几层真正的调用者。
+     *
+     * <p>用 {@code StackWalker} 而不是 {@code new Throwable().getStackTrace()}：
+     * 前者可以只取需要的深度，代价小得多 —— 虽然这是调试路径，
+     * 但它每帧要跑几十次，太慢会把时序本身也带偏，那就测不准了。
+     */
+    private static String caller() {
+        try {
+            List<String> frames = StackWalker.getInstance().walk(s -> s
+                    .map(f -> f.getClassName() + "#" + f.getMethodName())
+                    .filter(n -> !n.startsWith("com.tacz.guns.client.render.scope.ScopePipTrace"))
+                    .filter(n -> !n.contains("GameRendererMixin"))
+                    .skip(1)
+                    .limit(3)
+                    .collect(Collectors.toList()));
+            return String.join("  <-  ", frames);
+        } catch (Throwable t) {
+            return "<stack unavailable>";
+        }
+    }
+}

--- a/src/main/java/com/tacz/guns/client/render/scope/ScopePipTrace.java
+++ b/src/main/java/com/tacz/guns/client/render/scope/ScopePipTrace.java
@@ -46,10 +46,35 @@ public final class ScopePipTrace {
     /** 单帧内最多记录多少行，防御性上限（正常一帧几十行）。 */
     private static final int LINES_PER_FRAME = 400;
 
+    /**
+     * 【硬性兜底】最多<b>武装</b>这么多帧，之后无论有没有采到样本都永久收摊。
+     *
+     * <h3>为什么必须有这一条 —— 它修的是一次真实的崩溃</h3>
+     * 原来的收摊条件只有 {@link #FRAME_BUDGET}，而预算<b>只在
+     * {@code sawScopePass} 为真的帧才扣</b>，那个标志又只由
+     * {@code renderScopeView}（二次渲染那条路）发出的 {@code SCOPE-PASS BEGIN} 置位。
+     * <b>光影下二次渲染是被硬性拦下的</b>，于是那面旗永远立不起来 ⇒ 预算一分不扣 ⇒
+     * {@code enabled()} 永远为真 ⇒ 整局游戏每帧都在 {@code mainRenderTarget()} 上跑
+     * {@code StackWalker}（每帧最多 400 次，而 Sodium 地形、Voxy、帧图都会调它）。
+     *
+     * <p>后果不是「日志有点多」，而是<b>渲染线程被拖垮</b>：区块构建在工作线程照常堆积，
+     * 渲染线程追不上，{@code processChunkBuildResults} 只好一次性上传巨量结果，
+     * Sodium 的 {@code GlBufferArena.resize} 于是要一口气申请 88 MB
+     * （且扩容期间新旧缓冲并存 ≈ 2 倍），显存直接 {@code GpuOutOfMemoryException}。
+     * 实测：只在<b>四处跑图</b>时触发（那才有大量区块构建），静止测试区完全正常 ——
+     * 这也是它一开始被误判成「显存泄漏」的原因。
+     *
+     * <p>教训：诊断开关的收摊条件<b>绝不能依赖被诊断的那条路自己发信号</b> ——
+     * 那条路不跑，正是你要诊断的情形。所以这里补一个与任何业务逻辑无关的绝对上限。
+     */
+    private static final int ARMED_FRAME_LIMIT = 600;
+
     private static int framesTraced = 0;
+    private static int framesArmed = 0;
     private static int linesThisFrame = 0;
     private static boolean tracingThisFrame = false;
     private static boolean announced = false;
+    private static boolean loggedGiveUp = false;
 
     /**
      * 本帧的行缓冲。
@@ -72,7 +97,10 @@ public final class ScopePipTrace {
     public static boolean enabled() {
         return RenderConfig.SCOPE_PIP_DEBUG_TRACE != null
                 && RenderConfig.SCOPE_PIP_DEBUG_TRACE.get()
-                && framesTraced < FRAME_BUDGET;
+                && framesTraced < FRAME_BUDGET
+                // 与业务逻辑无关的绝对上限，见 ARMED_FRAME_LIMIT ——
+                // 没有它，采不到样本的场景下本开关会一直武装到游戏崩溃。
+                && framesArmed < ARMED_FRAME_LIMIT;
     }
 
     /**
@@ -95,6 +123,19 @@ public final class ScopePipTrace {
         sawScopePass = false;
         linesThisFrame = 0;
         tracingThisFrame = enabled();
+        if (tracingThisFrame) {
+            // 无条件计数：这一帧确实处于武装状态、确实会跑 StackWalker，就得算数。
+            // 绝不能只在「采到样本」时才计 —— 那正是原来那个 bug。
+            framesArmed++;
+        } else if (RenderConfig.SCOPE_PIP_DEBUG_TRACE != null
+                && RenderConfig.SCOPE_PIP_DEBUG_TRACE.get()
+                && framesArmed >= ARMED_FRAME_LIMIT && !loggedGiveUp) {
+            loggedGiveUp = true;
+            GunMod.LOGGER.info("[TACZ Scope][trace] Gave up after {} armed frames without capturing a "
+                            + "scope pass; tracing is now off for this session. Leaving it armed would "
+                            + "stall the render thread badly enough to starve terrain uploads. "
+                            + "Set ScopePipDebugTrace=false to silence this.", framesArmed);
+        }
         if (tracingThisFrame && !announced) {
             announced = true;
             GunMod.LOGGER.info("[TACZ Scope][trace] Armed: will capture {} frames that actually run the "
@@ -108,8 +149,12 @@ public final class ScopePipTrace {
         if (!tracingThisFrame) {
             return;
         }
-        if (what.startsWith("SCOPE-PASS BEGIN")) {
+        if (what.startsWith("SCOPE-PASS BEGIN") || what.startsWith("PIP COMPOSITE")) {
             // 这一帧值得记 —— 结算时才会落盘。
+            //
+            // 必须同时认「PIP COMPOSITE」：光影下走的是屏幕空间合成，
+            // 根本不存在 SCOPE-PASS。只认前者的话，光影下永远采不到样本、
+            // 预算永远扣不掉 —— 那正是拖垮渲染线程、进而撑爆显存的那个 bug。
             sawScopePass = true;
         }
         if (linesThisFrame++ > LINES_PER_FRAME) {

--- a/src/main/java/com/tacz/guns/client/renderer/item/AnimateGeoItemRenderer.java
+++ b/src/main/java/com/tacz/guns/client/renderer/item/AnimateGeoItemRenderer.java
@@ -284,6 +284,37 @@ public abstract class AnimateGeoItemRenderer<M extends BedrockAnimatedModel, CTX
     /**
      * 应用状态机的手持物品摄像机动画，暂时只用于玩家
      */
+    /**
+     * 开镜晃动缩放系数：腰射恒为 1，随开镜进度插值到 {@code AimingSwayIntensity}。
+     *
+     * <p>按开镜进度插值而不是「开镜就切换」，是为了避免抬镜那一瞬间晃动幅度突然跳一下 ——
+     * 那种跳变比晃动本身更容易被察觉。
+     *
+     * <p>整体包 try/catch：本方法在每帧的第一人称渲染路径上，
+     * 任何异常（配置尚未加载、玩家状态异常）都不该把持枪渲染带崩，
+     * 兜底返回 1 = 原有手感。
+     *
+     * @return 缩放系数；{@code 1} 表示与改动前完全一致
+     */
+    protected static float aimingSwayScale(LocalPlayer player, float partialTick) {
+        try {
+            if (com.tacz.guns.config.client.RenderConfig.AIMING_SWAY_INTENSITY == null) {
+                return 1.0F;
+            }
+            float intensity = com.tacz.guns.config.client.RenderConfig.AIMING_SWAY_INTENSITY.get().floatValue();
+            if (intensity == 1.0F) {
+                // 常见情形直接短路，省掉一次开镜进度查询。
+                return 1.0F;
+            }
+            float aimingProgress = Mth.clamp(
+                    com.tacz.guns.api.client.gameplay.IClientPlayerGunOperator.fromLocalPlayer(player)
+                            .getClientAimingProgress(partialTick), 0.0F, 1.0F);
+            return Mth.lerp(aimingProgress, 1.0F, intensity);
+        } catch (Throwable ignored) {
+            return 1.0F;
+        }
+    }
+
     public void applyItemInHandCameraAnimation(BeforeRenderHandEvent event, ItemStack stack, LocalPlayer player) {
         applyItemInHandCameraAnimation(event, stack, 1);
     }
@@ -317,16 +348,28 @@ public abstract class AnimateGeoItemRenderer<M extends BedrockAnimatedModel, CTX
         M model = getModel(stack);
         if (model != null) {
             poseStack.pushPose();
+            // 【持枪晃动 sway】枪跟不上视角转动的那一份滞后：
+            // getViewXRot 是当前朝向，xBob/yBob 是 vanilla 维护的平滑滞后值，两者之差
+            // 就是「刚才甩了多少」。甩得越快差值越大，枪甩动、镜像也跟着晃。
             float xRotOffset = Mth.lerp(partialTick, player.xBobO, player.xBob);
             float yRotOffset = Mth.lerp(partialTick, player.yBobO, player.yBob);
             float xRot = player.getViewXRot(partialTick) - xRotOffset;
             float yRot = player.getViewYRot(partialTick) - yRotOffset;
-            poseStack.mulPose(Axis.XP.rotationDegrees(xRot * -0.1F));
-            poseStack.mulPose(Axis.YP.rotationDegrees(yRot * -0.1F));
+            // 开镜时把晃动按配置缩放：开镜进度 0 → 恒为 1（腰射手感一点不变），
+            // 满开镜 → 取到 AimingSwayIntensity。默认 1.5 = 比原来更明显一些。
+            //
+            // 为什么值得单独放大：开镜后视野被瞄具收窄（PIP 更是把镜内又放大了 Z 倍），
+            // 同样的角度抖动在镜内被放大成同样倍数的位移 —— 现实里高倍镜正是这样「越放大越难稳住」。
+            // 原实现对开镜与否一视同仁，镜内反而显得过于稳定。
+            float swayScale = aimingSwayScale(player, partialTick);
+            poseStack.mulPose(Axis.XP.rotationDegrees(xRot * -0.1F * swayScale));
+            poseStack.mulPose(Axis.YP.rotationDegrees(yRot * -0.1F * swayScale));
             BedrockPart rootNode = model.getRootNode();
             if (rootNode != null) {
-                xRot = (float) Math.tanh(xRot / 25) * 25;
-                yRot = (float) Math.tanh(yRot / 25) * 25;
+                // tanh 饱和限幅保持在缩放【之前】：它的作用是防止快速转身时枪飞出画面，
+                // 那道保护必须先生效，缩放只放大限幅后的结果。
+                xRot = (float) Math.tanh(xRot / 25) * 25 * swayScale;
+                yRot = (float) Math.tanh(yRot / 25) * 25 * swayScale;
                 rootNode.offsetX += yRot * 0.1F / 16F / 3F;
                 rootNode.offsetY += -xRot * 0.1F / 16F / 3F;
                 rootNode.additionalQuaternion.mul(Axis.XP.rotationDegrees(xRot * 0.05F));

--- a/src/main/java/com/tacz/guns/client/renderer/item/GunItemRendererWrapper.java
+++ b/src/main/java/com/tacz/guns/client/renderer/item/GunItemRendererWrapper.java
@@ -328,16 +328,23 @@ public class GunItemRendererWrapper extends AnimateGeoItemRenderer<BedrockGunMod
                 }
             }
             // 逆转原版施加在手上的延滞效果，改为写入模型动画数据中
+            //
+            // 【这里是枪械实际走的那一份】与父类 AnimateGeoItemRenderer#renderFirstPerson
+            // 里那段是同一套公式的两份拷贝。改晃动手感时<b>两处必须同时改</b>，
+            // 否则只有一半路径生效，表现为「有的枪改了有的没改」。
+            // 缩放系数由父类的 aimingSwayScale 统一提供，避免两边算法漂移。
             float xRotOffset = Mth.lerp(partialTick, player.xBobO, player.xBob);
             float yRotOffset = Mth.lerp(partialTick, player.yBobO, player.yBob);
             float xRot = player.getViewXRot(partialTick) - xRotOffset;
             float yRot = player.getViewYRot(partialTick) - yRotOffset;
-            poseStack.mulPose(Axis.XP.rotationDegrees(xRot * -0.1F));
-            poseStack.mulPose(Axis.YP.rotationDegrees(yRot * -0.1F));
+            float swayScale = aimingSwayScale(player, partialTick);
+            poseStack.mulPose(Axis.XP.rotationDegrees(xRot * -0.1F * swayScale));
+            poseStack.mulPose(Axis.YP.rotationDegrees(yRot * -0.1F * swayScale));
             BedrockPart rootNode = gunModel.getRootNode();
             if (rootNode != null) {
-                xRot = (float) Math.tanh(xRot / 25) * 25;
-                yRot = (float) Math.tanh(yRot / 25) * 25;
+                // tanh 饱和限幅保持在缩放【之前】：它防的是快速转身时枪飞出画面。
+                xRot = (float) Math.tanh(xRot / 25) * 25 * swayScale;
+                yRot = (float) Math.tanh(yRot / 25) * 25 * swayScale;
                 rootNode.offsetX += yRot * 0.1F / 16F / 3F;
                 rootNode.offsetY += -xRot * 0.1F / 16F / 3F;
                 rootNode.additionalQuaternion.mul(Axis.XP.rotationDegrees(xRot * 0.05F));

--- a/src/main/java/com/tacz/guns/compat/iris/IrisCompat.java
+++ b/src/main/java/com/tacz/guns/compat/iris/IrisCompat.java
@@ -9,6 +9,7 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.VersionParsingException;
 import net.minecraft.client.renderer.SubmitNodeCollector;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Supplier;
 
@@ -233,6 +234,50 @@ public final class IrisCompat {
             return (Boolean) handRendererClass.getMethod("isActive").invoke(instance);
         } catch (Throwable ignored) {
             return false;
+        }
+    }
+
+    /** {@code HandRenderer.INSTANCE}，与 {@link #handIsRenderingSolidMethod} 一同惰性解析、解析一次。 */
+    @Nullable
+    private static Object handRendererInstance;
+    @Nullable
+    private static java.lang.reflect.Method handIsRenderingSolidMethod;
+    private static boolean handRenderingSolidResolved;
+
+    /**
+     * @return 当前是否处于 Iris 手部渲染的<b>实心</b>那一遍（{@code false} = 半透明那一遍）。
+     *
+     * <p>用来区分两次 {@code renderAllFeatures}：Iris 的 {@code HandRenderer} 一帧跑两遍手部，
+     * 而镜内画中画只能在<b>半透明</b>那遍成立 —— 只有它跑在
+     * {@code beginTranslucents() → deferredRenderer.renderAll()} 之后，
+     * {@code colortex0} 里才有已着色的场景。详见 {@code IrisHandTranslucentMixin}。</p>
+     *
+     * <p><b>句柄必须缓存。</b>本方法由 {@code IrisScopeMaskState.applyToGlRenderPass}
+     * 逐 draw call 调用，每次都 {@code Class.forName} + {@code getMethod} 会在热路径上
+     * 反复走反射查表并产生垃圾。这里解析一次（成功或失败都只试一次），之后只剩一次
+     * {@code invoke}。</p>
+     */
+    public static boolean isHandRenderingSolid() {
+        if (!handRenderingSolidResolved) {
+            handRenderingSolidResolved = true;
+            try {
+                Class<?> handRendererClass = Class.forName("net.irisshaders.iris.pathways.HandRenderer");
+                handRendererInstance = handRendererClass.getField("INSTANCE").get(null);
+                handIsRenderingSolidMethod = handRendererClass.getMethod("isRenderingSolid");
+            } catch (Throwable ignored) {
+                handRendererInstance = null;
+                handIsRenderingSolidMethod = null;
+            }
+        }
+        if (handRendererInstance == null || handIsRenderingSolidMethod == null) {
+            // 解析不到就当作「在实心那遍」—— 保守值，让镜身退回纯 discard（透视 1×），
+            // 而不是去采样一张可能还没着色的 colortex0（那就是黑镜片）。
+            return true;
+        }
+        try {
+            return (Boolean) handIsRenderingSolidMethod.invoke(handRendererInstance);
+        } catch (Throwable ignored) {
+            return true;
         }
     }
 

--- a/src/main/java/com/tacz/guns/compat/iris/IrisScopeMaskState.java
+++ b/src/main/java/com/tacz/guns/compat/iris/IrisScopeMaskState.java
@@ -106,7 +106,6 @@ public final class IrisScopeMaskState {
                 loggedApply = true;
                 GunMod.LOGGER.info("[TACZ Scope] Iris scope-mask bridge active (mode={}, textureUnit={}, textureId={}).", mode, unit, textureId);
             }
-
             GL20C.glUniform1i(modeLocation, mode);
             GL20C.glUniform1i(samplerLocation, unit);
             GL13C.glActiveTexture(GL13C.GL_TEXTURE0 + unit);
@@ -140,7 +139,23 @@ public final class IrisScopeMaskState {
                 return 0;
             }
             String normalized = path.toLowerCase(Locale.ROOT);
-            if (BODY_PIPELINE.equals(normalized) || FLASH_TRANSLUCENT_PIPELINE.equals(normalized)
+            if (BODY_PIPELINE.equals(normalized)) {
+                // 【恒为 1】镜身在孔径内 discard，于是最终画面里孔径那块就是 1× 的世界。
+                //
+                // 镜内的「放大」不在这里做 —— 那是
+                // {@code ScopePipRenderer.compositeAfterLevelUnderShaders()} 的活：
+                // 等 Iris 整条管线跑完，直接在最终画面上把孔径内那 1/Z 的小块放大铺满。
+                // 而「孔径内是干净的 1× 世界、没有枪」正是这里 discard 换来的前提。
+                //
+                // ↓ 以下是被推翻的旧方案，留作路标，别再走一遍 ↓
+                // 曾经让这里返回 3，由注入进 pack 着色器的分支去采样 colortexN。
+                // 两次实测都失败：先是纯黑（HAND_CUTOUT 跑在延迟光照之前，
+                // 那一刻没有任何 colortex 装着已着色的场景），把枪挪进半透明 pass 之后
+                // 又变成「灰噪块 + 黑」（场景色逐 pack 不同，Eclipse 在 colortex2）。
+                // 根子上这条路要求猜中别家 pack 的内部约定，怎么修都是下一次盲猜。
+                return 1;
+            }
+            if (FLASH_TRANSLUCENT_PIPELINE.equals(normalized)
                     || FLASH_SWIRL_PIPELINE.equals(normalized)) {
                 return 1;
             }

--- a/src/main/java/com/tacz/guns/compat/sodium/SodiumCompat.java
+++ b/src/main/java/com/tacz/guns/compat/sodium/SodiumCompat.java
@@ -1,0 +1,195 @@
+package com.tacz.guns.compat.sodium;
+
+import com.tacz.guns.GunMod;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.Minecraft;
+import org.joml.Matrix4f;
+import org.joml.Matrix4fc;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
+
+/**
+ * Sodium 兼容：同步它自己那份地形投影矩阵快照。
+ *
+ * <h2>为什么需要这个</h2>
+ * 「镜内二次渲染」要用一个更窄的 FOV 再画一遍世界。原版路径靠
+ * {@code RenderSystem.setProjectionMatrix(...)} 就能改，但 <b>Sodium 不看它</b>：
+ *
+ * <pre>
+ * Sodium GameRendererMixin
+ *   @WrapOperation ProjectionMatrixBuffer#getBuffer(Matrix4f)   // 在 renderLevel 里
+ *       → this.projection.set(那个矩阵)                          // 存进自己的字段
+ *   GameRendererStorage.sodium$getProjectionMatrix() → 该字段
+ *
+ * Sodium LevelRendererMixin
+ *   new ChunkRenderMatrices(sodium$getProjectionMatrix(), modelView)
+ *       → SodiumWorldRenderer.drawChunkLayer(...)                // 地形就用这份
+ * </pre>
+ *
+ * 第一版 PIP 只改了 {@code RenderSystem} 那一份，于是<b>地形用宽 FOV、
+ * 原版路径的实体用窄 FOV</b>，镜内两套比例叠在一起 —— 这正是当时实测到的
+ * 「部分物件放大、大部分方块没放大，画面糊在一起」。
+ *
+ * <h2>做法</h2>
+ * {@code sodium$getProjectionMatrix()} 返回的是那个字段<b>本身</b>（声明类型
+ * {@code Matrix4fc}，实际对象是可变的 {@code Matrix4f}），所以可以就地改写，
+ * 用完再写回原值。这是在动别人的内部状态，因此：
+ * <ul>
+ *   <li>全程反射 + {@code Throwable} 兜底，Sodium 不在、改名、换实现都只会安静降级；</li>
+ *   <li>返回值不是 {@code Matrix4f}（比如哪天换成不可变实现）就直接放弃，不硬来；</li>
+ *   <li>调用方必须用 try/finally 保证 {@link #restoreProjection} 一定执行。</li>
+ * </ul>
+ * 降级的后果是「镜内地形不跟着放大」，与第一版的表现一致 —— 难看，但不崩。
+ */
+@Environment(EnvType.CLIENT)
+public final class SodiumCompat {
+
+    private static final String STORAGE_INTERFACE = "net.caffeinemc.mods.sodium.client.util.GameRendererStorage";
+    private static final String GETTER = "sodium$getProjectionMatrix";
+
+    private static boolean loggedFailure = false;
+    private static boolean loggedSuccess = false;
+
+    /** 改写前的原值备份；{@code null} 表示本次没有改写成功，restore 时不必做事。 */
+    @Nullable
+    private static Matrix4f patchedField;
+    private static final Matrix4f SAVED = new Matrix4f();
+
+    private SodiumCompat() {
+    }
+
+    public static boolean isLoaded() {
+        return FabricLoader.getInstance().isModLoaded("sodium");
+    }
+
+    /**
+     * 把 Sodium 的地形投影快照临时换成 {@code narrow}。
+     *
+     * <p>必须与 {@link #restoreProjection()} 成对使用（try/finally）。
+     *
+     * @return 是否真的改写成功（false = Sodium 不在或反射失败，镜内地形将不跟随放大）
+     */
+    public static boolean overrideProjection(Matrix4fc narrow) {
+        patchedField = null;
+        if (!isLoaded()) {
+            return false;
+        }
+        try {
+            Object gameRenderer = Minecraft.getInstance().gameRenderer;
+            Class<?> storage = Class.forName(STORAGE_INTERFACE);
+            if (!storage.isInstance(gameRenderer)) {
+                logFailureOnce("GameRenderer does not implement " + STORAGE_INTERFACE);
+                return false;
+            }
+            Method getter = storage.getMethod(GETTER);
+            Object current = getter.invoke(gameRenderer);
+            if (!(current instanceof Matrix4f live)) {
+                // 声明类型是 Matrix4fc；若哪天真的换成不可变实现，就地改写不再成立。
+                logFailureOnce(GETTER + " did not return a mutable Matrix4f");
+                return false;
+            }
+            SAVED.set(live);
+            live.set(narrow);
+            patchedField = live;
+            if (!loggedSuccess) {
+                loggedSuccess = true;
+                GunMod.LOGGER.info("[TACZ Scope] Sodium terrain projection is being synced for the scope pass.");
+            }
+            return true;
+        } catch (Throwable t) {
+            logFailureOnce("reflection failed: " + t);
+            return false;
+        }
+    }
+
+    /** 还原 {@link #overrideProjection} 改写过的快照。没改写成功时是空操作。 */
+    public static void restoreProjection() {
+        if (patchedField != null) {
+            patchedField.set(SAVED);
+            patchedField = null;
+        }
+    }
+
+    /**
+     * 让 Sodium 相信「本帧还没上传过区块 uniform」，好让紧随其后的 vanilla 那一遍重新上传。
+     *
+     * <h2>这修的是什么 —— 也是「溢出」的真正病因</h2>
+     * {@code UniformBufferManager.update} 的第一句就是一道<b>每帧只做一次</b>的闸：
+     * <pre>
+     * public void update(ChunkRenderMatrices m, FogParameters fog) {
+     *     if (this.hasUpdatedThisFrame) return;     // ← 字节码偏移 0-7
+     *     this.hasUpdatedThisFrame = true;
+     *     ... 把 m.projection() 上传到 uniform buffer ...
+     * }
+     * public void prepareFrame() { this.hasUpdatedThisFrame = false; }
+     * </pre>
+     * 一帧里跑两遍世界渲染时，<b>镜内那一遍先到</b>：它带着窄 FOV 矩阵调 update，
+     * 上传成功并把闸关上。接着 vanilla 那一遍带着正常矩阵再调 update ——
+     * <b>直接 return</b>。于是主画面里 Sodium 的地形<b>全部用镜内那份窄投影绘制</b>。
+     *
+     * <p>这就是长期被当成「镜内画面溢出到镜外」的东西的真相：<b>根本不是溢出</b>。
+     * 没有任何像素跑出镜片，是<b>主画面自己的地形被用错了投影</b>画出来，
+     * 于是近处的水和冰柱被拉伸放大，而远处由 Voxy LOD 负责的地形（另一套 uniform 通路）
+     * 完好无损 —— 用户截图里「远山正常、旁边的冰柱却是放大的」正是这个签名。
+     *
+     * <p>之前所有「谁把画面画到主 target 上」的排查方向从一开始就找错了对象：
+     * 渲染目标的重定向<b>一直是对的</b>（诊断日志里镜内那一遍全程解析到离屏 target，
+     * 一次 MAIN 都没有）。错的是投影矩阵的<b>上传时机</b>。
+     *
+     * <p>解法就是在两遍之间调一次 {@code prepareFrame()} 把闸重新打开。
+     * 该方法是 public 的；拿到实例要走 {@code SodiumWorldRenderer.instanceNullable()}
+     * 再反射取 private 的 {@code uniformBufferManager} 字段。
+     * 反射失败就安静降级 —— 后果是回到当前这个已知症状，不会更糟。
+     */
+    public static void resetChunkUniformUpload() {
+        if (!isLoaded()) {
+            return;
+        }
+        try {
+            Class<?> worldRendererClass = Class.forName(
+                    "net.caffeinemc.mods.sodium.client.render.SodiumWorldRenderer");
+            Object worldRenderer = worldRendererClass.getMethod("instanceNullable").invoke(null);
+            if (worldRenderer == null) {
+                return;
+            }
+            java.lang.reflect.Field field = worldRendererClass.getDeclaredField("uniformBufferManager");
+            field.setAccessible(true);
+            Object manager = field.get(worldRenderer);
+            if (manager == null) {
+                return;
+            }
+            manager.getClass().getMethod("prepareFrame").invoke(manager);
+            if (!loggedResetSuccess) {
+                loggedResetSuccess = true;
+                GunMod.LOGGER.info("[TACZ Scope] Sodium chunk uniforms will be re-uploaded for the main pass "
+                        + "(this is what kept the main view on the scope's projection).");
+            }
+        } catch (Throwable t) {
+            logResetFailureOnce(t);
+        }
+    }
+
+    private static boolean loggedResetSuccess = false;
+    private static boolean loggedResetFailure = false;
+
+    private static void logResetFailureOnce(Throwable t) {
+        if (loggedResetFailure) {
+            return;
+        }
+        loggedResetFailure = true;
+        GunMod.LOGGER.warn("[TACZ Scope] Could not reset Sodium's per-frame chunk uniform flag ({}). "
+                + "The main view's terrain will keep rendering with the scope's projection.", t.toString());
+    }
+
+    private static void logFailureOnce(String detail) {
+        if (loggedFailure) {
+            return;
+        }
+        loggedFailure = true;
+        GunMod.LOGGER.warn("[TACZ Scope] Could not sync Sodium's terrain projection ({}). "
+                + "The scope's second render will show terrain at the wrong magnification.", detail);
+    }
+}

--- a/src/main/java/com/tacz/guns/config/client/RenderConfig.java
+++ b/src/main/java/com/tacz/guns/config/client/RenderConfig.java
@@ -117,6 +117,16 @@ public class RenderConfig {
      */
     public static ForgeConfigSpec.DoubleValue SCOPE_PIP_WORLD_ZOOM_SHARE;
     /**
+     * 开镜时持枪晃动的强度倍数（{@code 1.0} = 与改动前一致）。
+     *
+     * <p>晃动本身是「枪跟不上视角转动」的滞后量，腰射与开镜原本一视同仁。
+     * 但开镜后视野被瞄具收窄、镜内还被放大 Z 倍，同样的角度抖动在镜内会被放大同样的倍数
+     * —— 现实里高倍镜正是「越放大越难稳住」。本项让开镜那一档单独可调。
+     *
+     * <p>按开镜进度插值：腰射恒为 1，满开镜取到本值。{@code 0} = 满开镜时完全不晃。
+     */
+    public static ForgeConfigSpec.DoubleValue AIMING_SWAY_INTENSITY;
+    /**
      * 允许在光影包启用时也跑 PIP。默认<b>关闭</b>。
      *
      * <p>关闭是保守默认，不是「已知不兼容」—— 见 {@code ScopePipRenderer} 里的说明。
@@ -397,6 +407,22 @@ public class RenderConfig {
                         "Ignored when ScopePipRerender is on -- that path already renders at native",
                         "resolution, so zooming the world would cost image quality for nothing.")
                 .defineInRange("ScopePipWorldZoomShare", 0.0d, 0.0d, 1.0d);
+        AIMING_SWAY_INTENSITY = builder
+                .comment("How much the gun sways while aiming down sights, as a multiplier.",
+                        "",
+                        "Sway is the gun lagging behind your view when you turn -- it is what makes the",
+                        "sight picture drift and settle. Hip fire is never affected by this setting; the",
+                        "value is blended in by aiming progress, so it reaches full strength only when",
+                        "fully scoped.",
+                        "  0.0 = rock steady once fully aimed, no sway at all",
+                        "  1.0 = the original amount, identical to before this option existed",
+                        "  1.5 = default, noticeably more alive without being hard to aim",
+                        "  3.0+ = heavy, deliberately difficult",
+                        "Worth raising with high-power optics: a narrow field of view (and the PIP lens,",
+                        "which magnifies by the scope's zoom on top) multiplies the same angular wobble,",
+                        "the way real magnified optics get harder to hold steady.",
+                        "The fast-turn safety clamp still applies, so the gun cannot swing off screen.")
+                .defineInRange("AimingSwayIntensity", 1.5d, 0.0d, 5.0d);
         SCOPE_PIP_ALLOW_SHADER_PACKS = builder
                 .comment("Allow the scope picture-in-picture to run while a shader pack is active.",
                         "Off by default as a precaution, NOT because it is known to be broken: under a",

--- a/src/main/java/com/tacz/guns/config/client/RenderConfig.java
+++ b/src/main/java/com/tacz/guns/config/client/RenderConfig.java
@@ -450,7 +450,15 @@ public class RenderConfig {
                         "for the first few frames only. Any line marked MAIN between SCOPE-PASS BEGIN",
                         "and SCOPE-PASS END is imagery escaping onto the screen; anything logged after",
                         "the vanilla clear means a renderer submits its draws late and cannot be",
-                        "redirected at all.")
+                        "redirected at all.",
+                        "",
+                        "EXPENSIVE. While armed this walks the call stack on every render-target",
+                        "resolve, and Sodium, Voxy and the frame graph all hit that path many times a",
+                        "frame. Leave it off for normal play: it stalls the render thread enough that",
+                        "terrain uploads pile up, and the resulting oversized GPU buffer request can",
+                        "fail outright while exploring. It now disarms itself after a few hundred",
+                        "frames regardless, but there is no reason to pay for it unless you are",
+                        "chasing a scope render bug.")
                 .define("ScopePipDebugTrace", false);
         SCOPE_PIP_DEBUG_PAINT_LENS = builder
                 .comment("[DEBUG] Paint the area the scope composite actually covers in solid magenta.",

--- a/src/main/java/com/tacz/guns/config/client/RenderConfig.java
+++ b/src/main/java/com/tacz/guns/config/client/RenderConfig.java
@@ -82,7 +82,78 @@ public class RenderConfig {
     public static ForgeConfigSpec.BooleanValue DISABLE_MOVEMENT_ATTRIBUTE_FOV;
     public static ForgeConfigSpec.BooleanValue ENABLE_TACZ_ID_IN_TOOLTIP;
     public static ForgeConfigSpec.BooleanValue BLOCK_ENTITY_TRANSLUCENT;
-    /** 第 18 轮：PIP 镜内渲染 P1 验证开关，默认关闭。 */
+    /**
+     * 瞄准镜「镜内画中画（PIP）」总开关。默认<b>关闭</b>。
+     *
+     * <p>开启后世界 FOV <b>不再</b>整屏变焦（{@code CameraSetupEvent#applyScopeMagnification}
+     * 对装了倍镜的枪整体让位），改为把已画好的世界拷一份、按倍率在屏幕空间重投影，
+     * 再由目镜掩码把这张图贴进镜片孔径 —— 于是镜外保持 1×、只有镜片里是放大的。
+     *
+     * <p>代价是镜内画面来自主画面中心裁切区的放大，高倍镜（6× 以上）会明显变软。
+     * 因为这属于观感取舍而非性能取舍，默认关闭、由玩家自己选。
+     */
+    public static ForgeConfigSpec.BooleanValue SCOPE_PIP_ENABLE;
+    /** 开镜进度低于该值时不做 PIP（此时孔径几乎闭合，拷贝纯属浪费）。 */
+    public static ForgeConfigSpec.DoubleValue SCOPE_PIP_MIN_AIMING_PROGRESS;
+    /**
+     * 镜内锐化强度（0 = 关）。
+     *
+     * <p>镜内画面是主画面中心区按倍率放大来的，放大倍数<b>就是</b>瞄具倍率 ——
+     * 6 倍镜就是 6× 放大，必然变软。锐化不能凭空造出细节，但能显著挽回主观锐度。
+     * 实际强度按倍率线性加权（1× 不锐化，6× 及以上取满），所以低倍镜不会被过度处理。
+     */
+    public static ForgeConfigSpec.DoubleValue SCOPE_PIP_SHARPNESS;
+    /**
+     * 瞄具倍率里有多大一份由<b>世界</b>承担（0 = 全归镜内，纯 PIP；1 = 全归世界，等于关掉 PIP）。
+     *
+     * <p>镜内清晰度的硬上限是「屏幕分辨率 ÷ 镜内放大倍数」。倍率是相乘的，
+     * 按 {@code 世界 = Z^share、镜内 = Z^(1-share)} 拆分后总倍率恒为 Z，
+     * 而镜内拿到的真实像素<b>多 Z^share 倍</b>。
+     * 这是唯一能真正增加镜内分辨率（而非仅提升主观锐度）的旋钮。
+     *
+     * <p>刻意用<b>比例</b>而不是绝对倍率上限：后者会被 Z 夹住，
+     * 于是任何 ≥ Z 的取值都让镜内倍率退化成 1（PIP 名存实亡），
+     * 且那个临界点随瞄具倍率漂移 —— 实测中玩家正是撞上了这条。
+     */
+    public static ForgeConfigSpec.DoubleValue SCOPE_PIP_WORLD_ZOOM_SHARE;
+    /**
+     * 允许在光影包启用时也跑 PIP。默认<b>关闭</b>。
+     *
+     * <p>关闭是保守默认，不是「已知不兼容」—— 见 {@code ScopePipRenderer} 里的说明。
+     */
+    public static ForgeConfigSpec.BooleanValue SCOPE_PIP_ALLOW_SHADER_PACKS;
+    /**
+     * 镜内画面改用「窄 FOV 把世界再画一遍」，而不是重投影主画面。默认<b>关闭</b>。
+     *
+     * <p>重投影的镜内分辨率上限是「屏幕分辨率 ÷ 倍率」—— 8 倍镜下惨不忍睹。
+     * 本模式的镜内像素是真画出来的，没有那个上限；代价是每帧多跑一遍完整世界渲染。
+     *
+     * <p>已知：与 Sodium 的地形投影快照需要同步（{@code SodiumCompat} 负责）；
+     * 早前的实现还出现过「镜外实体消失」，尚未定位，所以默认关闭、按需自测。
+     */
+    public static ForgeConfigSpec.BooleanValue SCOPE_PIP_RERENDER;
+    /**
+     * 【诊断】跑完镜内那一遍，但<b>不做合成</b>。
+     *
+     * <p>用来一刀切开「放大画面溢出到镜外」这个症状的两种可能：
+     * <ul>
+     *   <li>画面干净（只有正常世界、镜片里什么都没有）→ 二次渲染是<b>关在离屏 target 里</b>的，
+     *       溢出来自合成/掩码；</li>
+     *   <li>放大画面照样溢出 → 二次渲染<b>漏到主画面</b>了，与合成无关。</li>
+     * </ul>
+     * 两种情况的修法完全不同，靠肉眼看成品是分不出来的。
+     */
+    public static ForgeConfigSpec.BooleanValue SCOPE_PIP_DEBUG_NO_COMPOSITE;
+    /**
+     * 【诊断】把镜内那一遍期间的渲染目标解析顺序打进日志（只记前几帧）。
+     * 见 {@code ScopePipTrace} 的类注释 —— 这个症状靠静态分析已经连错四次。
+     */
+    public static ForgeConfigSpec.BooleanValue SCOPE_PIP_DEBUG_TRACE;
+    /**
+     * 【诊断】把合成实际覆盖到的区域涂成纯品红。
+     * 整屏变品红 = 合成没被掩码约束住；只有镜片变品红 = 合成是对的，溢出来自别处。
+     */
+    public static ForgeConfigSpec.BooleanValue SCOPE_PIP_DEBUG_PAINT_LENS;
 
     public static void init(ForgeConfigSpec.Builder builder) {
         builder.push("render");
@@ -287,9 +358,79 @@ public class RenderConfig {
         builder.comment("Whether or not to automatically select the gun smith table's held item filter when opening it with a gun, attachment or ammo in main hand");
         AUTO_SELECT_GUN_SMITH_TABLE_FILTER = builder.define("AutoSelectGunSmithTableFilter", true);
 
-        builder.comment("[DEBUG] Enable the scope picture-in-picture (PIP) stage-1 verification. "
-                + "Only creates an off-screen render target and verifies output redirection works; "
-                + "does not yet render the world inside the scope. Default off.");
+        SCOPE_PIP_ENABLE = builder
+                .comment("Magnify only INSIDE the scope lens instead of zooming the whole screen",
+                        "(picture-in-picture). The view around the scope tube stays at 1x.",
+                        "Implemented by reprojecting a copy of the already-rendered frame, so it costs",
+                        "one fullscreen copy and works with Sodium/other terrain renderers.",
+                        "Tradeoff: the lens magnifies a centre crop of the frame, so high-power scopes",
+                        "(6x and up) look noticeably softer than the surrounding view.",
+                        "Requires ScopeMaskEnable and is skipped while a shader pack is active. Default off.")
+                .define("ScopePipEnable", false);
+        SCOPE_PIP_MIN_AIMING_PROGRESS = builder
+                .comment("Skip the picture-in-picture work while the aiming progress is below this value",
+                        "(the ocular aperture is still nearly closed down there).")
+                .defineInRange("ScopePipMinAimingProgress", 0.05d, 0.0d, 1.0d);
+        SCOPE_PIP_SHARPNESS = builder
+                .comment("Sharpening applied to the scope image (0 = off). The lens magnifies a centre crop",
+                        "of the frame by exactly the scope's zoom factor, so high-power optics are soft;",
+                        "sharpening cannot invent detail but recovers a lot of apparent crispness.",
+                        "Strength is scaled by magnification, so low-power optics stay untouched.")
+                .defineInRange("ScopePipSharpness", 0.5d, 0.0d, 1.0d);
+        SCOPE_PIP_WORLD_ZOOM_SHARE = builder
+                .comment("How much of the scope's magnification the WORLD takes, instead of the lens.",
+                        "Trades the purity of PIP for real sharpness inside the lens.",
+                        "",
+                        "The lens magnifies a centre crop of the frame, so at Zx it only has 1/Z of the",
+                        "screen's pixels to work with -- that is the whole reason high-power optics look",
+                        "soft. Zoom factors multiply, so the split is:",
+                        "    world = Z^share      lens = Z^(1-share)      world * lens = Z always",
+                        "The lens gets 'world' times more real pixels to build the image from.",
+                        "",
+                        "  0.0 = the lens does all the work; outside stays 1x (purest PIP, softest)",
+                        "  0.5 = split evenly; the lens image is built from sqrt(Z)x more real pixels",
+                        "  1.0 = the world does all the work (identical to turning PIP off)",
+                        "",
+                        "Total magnification is always exactly the scope's zoom, at every setting --",
+                        "this only moves where it comes from. Scale-independent, so the same value",
+                        "behaves the same on a 2x and an 8x optic.",
+                        "Ignored when ScopePipRerender is on -- that path already renders at native",
+                        "resolution, so zooming the world would cost image quality for nothing.")
+                .defineInRange("ScopePipWorldZoomShare", 0.0d, 0.0d, 1.0d);
+        SCOPE_PIP_ALLOW_SHADER_PACKS = builder
+                .comment("Allow the scope picture-in-picture to run while a shader pack is active.",
+                        "Off by default as a precaution, NOT because it is known to be broken: under a",
+                        "deferred shader pipeline the captured frame may not be fully shaded yet, and the",
+                        "composite writes raw colour before tonemapping, so the lens could look flat or",
+                        "blown out. Nothing can be corrupted by trying it - turn it on and look.")
+                .define("ScopePipAllowShaderPacks", false);
+        SCOPE_PIP_RERENDER = builder
+                .comment("Draw the scope image by rendering the world a SECOND time with a narrow FOV,",
+                        "instead of reprojecting the already-rendered frame. The lens then has native",
+                        "resolution instead of being capped at screen resolution / zoom, which matters a",
+                        "lot for 6x-8x optics. Costs a full extra world render every frame.",
+                        "EXPERIMENTAL: an earlier attempt made entities vanish from the main view.",
+                        "Default off.")
+                .define("ScopePipRerender", false);
+        SCOPE_PIP_DEBUG_NO_COMPOSITE = builder
+                .comment("[DEBUG] Run the scope pass but skip pasting it into the lens. Use this to tell",
+                        "whether magnified imagery leaking outside the scope comes from the off-screen",
+                        "pass escaping onto the screen, or from the composite/mask not confining it:",
+                        "  clean screen, empty lens -> the off-screen pass is contained; blame the composite",
+                        "  magnified imagery still leaks -> the pass itself is escaping to the main target")
+                .define("ScopePipDebugNoComposite", false);
+        SCOPE_PIP_DEBUG_TRACE = builder
+                .comment("[DEBUG] Log which code resolves which render target during the scope pass,",
+                        "for the first few frames only. Any line marked MAIN between SCOPE-PASS BEGIN",
+                        "and SCOPE-PASS END is imagery escaping onto the screen; anything logged after",
+                        "the vanilla clear means a renderer submits its draws late and cannot be",
+                        "redirected at all.")
+                .define("ScopePipDebugTrace", false);
+        SCOPE_PIP_DEBUG_PAINT_LENS = builder
+                .comment("[DEBUG] Paint the area the scope composite actually covers in solid magenta.",
+                        "  whole screen magenta -> the composite is NOT confined by the ocular mask",
+                        "  only the lens magenta -> the composite is fine and the leak is elsewhere")
+                .define("ScopePipDebugPaintLens", false);
 
         builder.comment("Max time the damage counter will reset");
         DAMAGE_COUNTER_RESET_TIME = builder.defineInRange("DamageCounterResetTime", 2000, 10, Integer.MAX_VALUE);

--- a/src/main/java/com/tacz/guns/mixin/client/FeatureRenderDispatcherMixin.java
+++ b/src/main/java/com/tacz/guns/mixin/client/FeatureRenderDispatcherMixin.java
@@ -1,6 +1,7 @@
 package com.tacz.guns.mixin.client;
 
 import com.tacz.guns.client.render.scope.ScopeMaskRenderer;
+import com.tacz.guns.client.render.scope.ScopePipRenderer;
 import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
 import org.spongepowered.asm.mixin.Mixin;
@@ -68,5 +69,14 @@ public abstract class FeatureRenderDispatcherMixin {
         // 上一轮的空 pass 探针已证明这个时机安全（实测预览块变绿），
         // 结论固化后探针即删除，不留死代码。
         ScopeMaskRenderer.renderAtPhaseBoundary();
+        // 【镜内画中画】紧跟掩码之后合成。三者的先后关系是硬约束：
+        //
+        //   掩码           -> 知道镜内是哪些像素
+        //   合成（这一句）  -> 那些像素被贴上离屏渲染的放大世界
+        //   executeSolid…  -> 镜身在镜内 discard（PIP 画面得以留住）；
+        //                     准星反向裁剪只画镜内（浮在 PIP 画面之上）
+        //
+        // 往前挪掩码还没就绪，往后挪（比如手持渲染之后）准星会被 PIP 盖掉。
+        ScopePipRenderer.compositeAtPhaseBoundary();
     }
 }

--- a/src/main/java/com/tacz/guns/mixin/client/GameRendererMixin.java
+++ b/src/main/java/com/tacz/guns/mixin/client/GameRendererMixin.java
@@ -1,16 +1,22 @@
 package com.tacz.guns.mixin.client;
 
 import cn.sh1rocu.simplebedrockmodel.api.event.RenderTickEvent;
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.resource.CrossFrameResourcePool;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.tacz.guns.api.client.event.RenderItemInHandBobEvent;
 import com.tacz.guns.api.client.event.RenderLevelBobEvent;
 import com.tacz.guns.client.render.scope.ScopeMaskRenderer;
+import com.tacz.guns.client.render.scope.ScopePipRenderer;
+import com.tacz.guns.client.render.scope.ScopePipTrace;
 import com.tacz.guns.client.renderer.other.GunHurtBobTweak;
 import com.tacz.guns.compat.iris.IrisCompat;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.fog.FogRenderer;
+import net.minecraft.client.renderer.state.GameRenderState;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import org.joml.Matrix4fc;
 import org.spongepowered.asm.mixin.Final;
@@ -20,11 +26,22 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /** 26.2 bob hooks using CameraRenderState signatures. */
 @Mixin(GameRenderer.class)
 public abstract class GameRendererMixin {
     @Shadow @Final private Minecraft minecraft;
+
+    /**
+     * 二次渲染那一遍要用的三样东西，全部取自 GameRenderer 自己的字段。
+     *
+     * <p>不用 @Inject(locals = ...) 捕获 renderLevel 的局部变量：局部变量表随编译器与版本漂移，
+     * 捕获式注入极脆。而这三个字段正是 vanilla 传给 LevelRenderer#render 的那几个实参的来源。</p>
+     */
+    @Shadow @Final private CrossFrameResourcePool resourcePool;
+    @Shadow @Final private FogRenderer fogRenderer;
+    @Shadow @Final private GameRenderState gameRenderState;
 
     @Unique
     private boolean tacz$renderingItemInHand;
@@ -98,6 +115,130 @@ public abstract class GameRendererMixin {
                 ci.cancel();
             }
         }
+    }
+
+    /**
+     * 【镜内画中画 · 抓取本帧世界画面】世界画完、视模开画之前，把主画面拷一份走。
+     *
+     * <h2>为什么正好是这一刻</h2>
+     * 镜内那张图是主画面按倍率重采样来的，所以拷贝必须夹在一个很窄的窗口里：
+     * <ul>
+     *   <li>{@code LevelRenderer#render} 之<b>后</b> —— 早一点世界还没画完；</li>
+     *   <li>{@code renderItemInHand} 之<b>前</b> —— 晚一点拷贝里就混进了枪和手，
+     *       镜片里会出现一把缩小的枪。</li>
+     * </ul>
+     * renderLevel 偏移 405 之后、502 之前正是这个唯一窗口。
+     *
+     * <h2>这里不再重定向任何 target</h2>
+     * 早前的版本在这个位置把 {@code mainRenderTarget()} 换成离屏 target、
+     * 再跑一次 {@code LevelRenderer#render}。那条路<b>与 Sodium 不兼容</b>（实测）：
+     * Sodium 接管地形渲染后根本不走 {@code mainRenderTarget()}，
+     * 重定向只对原版路径的实体/粒子生效，镜内两套画面糊在一起；
+     * 而一帧内两次驱动 {@code LevelRenderer#render} 还会打乱 Sodium 与
+     * ImmediatelyFast 的逐帧状态，把镜外的实体也弄没。
+     *
+     * <p>现在只剩一次 {@code copyTextureToTexture} —— 只读最终颜色缓冲，
+     * 那些像素是谁画的都无所谓，因此对任何地形渲染替换 mod 都天然兼容。</p>
+     */
+    @Inject(
+            method = "renderLevel",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/LevelRenderer;render(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/renderer/state/level/CameraRenderState;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;Z)V",
+                    shift = At.Shift.AFTER
+            )
+    )
+    private void tacz$captureSceneForScopePip(DeltaTracker deltaTracker, CallbackInfo ci) {
+        ScopePipTrace.mark("VANILLA LevelRenderer#render END (anything after this draws over the finished world)");
+        ScopePipRenderer.captureScene(this.minecraft);
+        // 【光影路径】Iris 把手部渲染搬进了 LevelRenderer#render 内部，所以此刻整条
+        // Iris 管线已经收工，主 target 里是最终画面 —— 直接在它上面做镜内放大。
+        // 无光影时这一句立即返回（合成仍在阶段边界完成，那里才能让准星盖在 PIP 之上）。
+        ScopePipRenderer.compositeAfterLevelUnderShaders();
+    }
+
+    /**
+     * 【二次渲染模式】用窄 FOV 把世界再画一遍，插在 vanilla 主世界渲染<b>之前</b>。
+     *
+     * <p>与上面的拷贝注入点刻意<b>相反</b>（BEFORE 而不是 AFTER），因为两种模式的约束相反：
+     * <ul>
+     *   <li>拷贝要 AFTER —— 世界得先画完才有得拷；</li>
+     *   <li>二次渲染要 BEFORE —— 让 vanilla 那一遍<b>收尾</b>，
+     *       把我们可能污染到的共享状态覆盖回去。最典型的是
+     *       {@code LevelRenderer.entityOutlineTarget}：它是字段持有、尺寸跟窗口走，
+     *       而发光描边 post chain 按 {@code mainRenderTarget()} 的尺寸入帧图；
+     *       我们重定向期间写进去的那份，会被 {@code renderLevel} 返回后的
+     *       {@code doEntityOutline()}（GameRenderer 偏移 275）贴到真实主画面上。
+     *       跑在前面，vanilla 随后就把它覆盖了。</li>
+     * </ul>
+     * 两个注入点各自判断模式，同一时刻只有一个会真正做事。
+     *
+     * <p>注入点选 {@code INVOKE + BEFORE} 而不是方法 HEAD：投影矩阵（偏移 291-303）
+     * 与雾缓冲（316-338）都在那之后、这次调用之前才准备好，而我们两样都要用。</p>
+     */
+    @Inject(
+            method = "renderLevel",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/LevelRenderer;render(Lcom/mojang/blaze3d/resource/GraphicsResourceAllocator;Lnet/minecraft/client/DeltaTracker;ZLnet/minecraft/client/renderer/state/level/CameraRenderState;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lorg/joml/Vector4f;Z)V",
+                    shift = At.Shift.BEFORE
+            )
+    )
+    private void tacz$renderScopePipView(DeltaTracker deltaTracker, CallbackInfo ci) {
+        ScopePipRenderer.renderScopeView(this.minecraft, this.resourcePool,
+                this.fogRenderer, this.gameRenderState, deltaTracker);
+        // 紧接着就是 vanilla 那一遍。有了这个界标，日志里「谁在什么阶段解析了哪个 target」
+        // 就能一眼分段：镜内那一遍 / vanilla 那一遍 / 之后。
+        ScopePipTrace.mark("VANILLA LevelRenderer#render BEGIN (its clear pass wipes the main target)");
+    }
+
+    /**
+     * 【二次渲染模式 · 输出重定向】那一遍期间，把主 target 换成离屏 target。
+     *
+     * <p>Sodium 的地形输出<b>也</b>走这个方法（{@code TerrainRenderPass} 字节码实读），
+     * 所以一处注入就能把原版路径与 Sodium 地形一起带走。
+     * 第一版之所以镜内地形没跟着放大，不是这里没生效，而是 Sodium 的<b>投影</b>
+     * 另有一份快照 —— 那条由 {@code SodiumCompat} 负责。</p>
+     *
+     * <p>刻意注入<b>方法</b>而不是 {@code @Accessor} 改
+     * {@code private final mainRenderTarget} 字段：final 字段可能被 JIT 常量折叠，
+     * 也容易被别处缓存住引用，而所有调用方取 target 走的都是这个 public 方法。</p>
+     *
+     * <p>{@link ScopePipRenderer#redirectTarget()} 只在那一次调用的 try/finally
+     * 窗口内返回非 null，其余任何时候都返回 null，所以对不开二次渲染的玩家
+     * 这就是一次 null 判断。</p>
+     */
+    @Inject(method = "mainRenderTarget", at = @At("HEAD"), cancellable = true)
+    private void tacz$redirectMainRenderTarget(CallbackInfoReturnable<RenderTarget> cir) {
+        RenderTarget scopeTarget = ScopePipRenderer.redirectTarget();
+        // 【诊断】这里是所有渲染目标解析的必经之路 —— Sodium 的 TerrainRenderPass、
+        // 经由它的 Voxy、vanilla 的 clear lambda、帧图导入，全都从这过。
+        // 打开 ScopePipDebugTrace 就能看清「镜内那一遍期间谁还在解析真正的主 target」。
+        if (ScopePipTrace.enabled()) {
+            ScopePipTrace.targetResolved(scopeTarget, scopeTarget != null);
+        }
+        if (scopeTarget != null) {
+            cir.setReturnValue(scopeTarget);
+        }
+    }
+
+    /**
+     * 每帧唯一的「瞄具帧状态归零」点。
+     *
+     * <p>接在 {@code extract} 的 HEAD 上，因为 {@code Minecraft#runTick} 的顺序是
+     * <b>extract（偏移 441）→ render（偏移 520）</b> —— 这是本帧最早、且一定会执行到的位置，
+     * 于是本帧所有消费者（{@code extract} 里的 FOV 事件、{@code renderLevel} 里的镜内抓取、
+     * 手部 pass 里的合成）看到的都是同一份定义明确的状态。</p>
+     *
+     * <p>绝不能放在手部 pass 里归零：Iris 的 {@code HandRenderer} 一帧调用两次
+     * {@code renderAllFeatures}（{@code renderSolid} 与 {@code renderTranslucent}，
+     * 两次 {@code ACTIVE} 都为 true），第二次会把第一次的结果抹掉，
+     * 导致光影下 PIP 永远看不到掩码。详见 {@code ScopeMaskRenderer#maskDrawnThisFrame}。</p>
+     */
+    @Inject(method = "extract", at = @At("HEAD"))
+    private void tacz$beginScopeFrame(DeltaTracker deltaTracker, boolean renderLevel, CallbackInfo ci) {
+        ScopeMaskRenderer.beginFrame();
+        ScopePipTrace.beginFrame();
     }
 
     @Inject(method = "render", at = @At("HEAD"))

--- a/src/main/java/com/tacz/guns/mixin/client/SkyRendererMixin.java
+++ b/src/main/java/com/tacz/guns/mixin/client/SkyRendererMixin.java
@@ -1,0 +1,59 @@
+package com.tacz.guns.mixin.client;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.tacz.guns.client.render.scope.ScopePipRenderer;
+import net.minecraft.client.renderer.SkyRenderer;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+/**
+ * 让天空渲染跟随「镜内二次渲染」的输出重定向。
+ *
+ * <h2>它补的是哪个洞</h2>
+ * 二次渲染靠注入 {@code GameRenderer#mainRenderTarget()} 把整遍世界引到离屏 target。
+ * 全 26.2 客户端里调用该方法的类<b>只有 {@link SkyRenderer} 一个会把结果缓存下来</b>：
+ * <pre>
+ * // LevelRenderer 偏移 64-87
+ * this.skyRenderer = new SkyRenderer(textureManager, atlasManager, gameRenderer.mainRenderTarget());
+ * // SkyRenderer
+ * private final RenderTarget renderTarget;   // 构造时定死，之后再不重新问
+ * </pre>
+ * 其余调用方（{@code ChunkSectionLayerGroup}、{@code CloudRenderer}、
+ * {@code QuadParticleFeatureRenderer}、{@code WorldBorderRenderer}、{@code OutputTarget}，
+ * 以及 Sodium 的 {@code TerrainRenderPass}）都是<b>每次用的时候现问</b>，所以重定向对它们天然生效。
+ *
+ * <p>后果是：{@code skyRenderer} 是在进世界时用<b>真实主 target</b> 构造的，
+ * 于是镜内那一遍的天空、太阳、月亮、星星<b>全部画到了屏幕上</b> ——
+ * 表现为放大的天空糊在镜筒外面，和正常画面撞在一起。
+ * 用户实测原话：「rerender 本该只在镜内的放大画面溢出到镜外，两个渲染撞在一起」，
+ * 且<b>开不开光影都一样</b> —— 正是因为这条与光影无关，纯粹是缓存引用的问题。
+ *
+ * <h2>为什么改字段读取而不是别的</h2>
+ * 那个字段是 {@code private final}，且在 {@code renderSkyDisc} / {@code renderDarkDisc} /
+ * {@code renderSun} / {@code renderMoon} / {@code renderStars} 里各读两次
+ * （颜色附件 + 深度附件）。与其逐个方法注入，不如直接改<b>字段读取表达式</b>的值：
+ * 一处覆盖全部读点，将来 vanilla 增删调用点也不用跟着改。
+ *
+ * <p>{@code opcode = GETFIELD} 把构造函数里那次 {@code putfield} 排除在外，
+ * 所以字段本身仍然是构造时那个真实主 target，我们只在<b>读的瞬间</b>换掉。
+ * 重定向窗口之外 {@link ScopePipRenderer#redirectTarget()} 恒返回 null，
+ * 此时这里原样返回 {@code original}，等于没有这个 mixin。
+ */
+@Mixin(SkyRenderer.class)
+public abstract class SkyRendererMixin {
+
+    @ModifyExpressionValue(
+            method = "*",
+            at = @At(
+                    value = "FIELD",
+                    target = "Lnet/minecraft/client/renderer/SkyRenderer;renderTarget:Lcom/mojang/blaze3d/pipeline/RenderTarget;",
+                    opcode = Opcodes.GETFIELD
+            )
+    )
+    private RenderTarget tacz$redirectSkyTargetForScopePip(RenderTarget original) {
+        RenderTarget scopeTarget = ScopePipRenderer.redirectTarget();
+        return scopeTarget != null ? scopeTarget : original;
+    }
+}

--- a/src/main/java/com/tacz/guns/mixin/client/iris/IrisShaderCreatorMixin.java
+++ b/src/main/java/com/tacz/guns/mixin/client/iris/IrisShaderCreatorMixin.java
@@ -24,10 +24,12 @@ public abstract class IrisShaderCreatorMixin {
         String patched = tacz$injectScopeMask(source);
         if (patched != source && !tacz$loggedPatch) {
             tacz$loggedPatch = true;
-            GunMod.LOGGER.info("[TACZ Scope] Injecting dormant scope-mask branch into Iris linked fragment shaders.");
+            GunMod.LOGGER.info("[TACZ Scope] Injected the scope-mask clip branch into Iris linked "
+                    + "fragment shaders (discard only; no colortex is sampled).");
         }
         return patched;
     }
+
 
     private static String tacz$injectScopeMask(String source) {
         if (source.contains("tacz_ScopeMaskMode")) {
@@ -41,8 +43,22 @@ public abstract class IrisShaderCreatorMixin {
         if (brace < 0) {
             return source;
         }
-
-        String declarations = "\n// TACZ Iris scope mask bridge: 0=off, 1=body discard-inside, 2=reticle discard-outside\n"
+        // 【这里只做 discard，不写颜色 —— 别再往回加采样了】
+        //
+        // 镜内放大由 {@code ScopePipRenderer.compositeAfterLevelUnderShaders()} 在
+        // Iris 整条管线跑完之后、直接在最终画面上完成。这里的职责只剩一件：
+        // 让镜身在孔径内 discard，于是最终画面里孔径那块是干净的 1× 世界 ——
+        // 那正是后续放大所需要的、不含枪的素材。
+        //
+        // 曾经在这里注入「采样 colortexN 并写颜色」，两次实测都失败：
+        //   ① 采 colortex0 → 纯黑（gbuffers_hand 跑在延迟光照之前，没有已着色的场景）；
+        //   ② 把枪挪进半透明 pass、再按 pack 的 RENDERTARGETS 采 colortex2 → 灰噪块。
+        // 根子上这条路要求猜中别家 pack 的内部缓冲约定，每修一次都是下一次盲猜；
+        // 而且它还引入过一次严重回归：为采样补 colortex 声明时前缀撞名，
+        // 导致 `undefined variable "colortex1"` → Iris 整体禁用光影 → Voxy 视口全 0。
+        // 现在这段注入完全不引用任何 colortex，那类事故从根上消失了。
+        String declarations = "\n// TACZ Iris scope mask bridge: 0=off, 1=body discard-inside, "
+                + "2=reticle discard-outside\n"
                 + "uniform int tacz_ScopeMaskMode;\n"
                 + "uniform sampler2D tacz_ScopeMaskSampler;\n\n";
 

--- a/src/main/resources/assets/tacz/shaders/core/scope_pip.fsh
+++ b/src/main/resources/assets/tacz/shaders/core/scope_pip.fsh
@@ -1,0 +1,177 @@
+#version 330
+
+// 瞄准镜「镜内画中画」合成片元着色器。
+//
+// 一个全屏三角形（顶点由 vanilla core/screenquad.vsh 用 gl_VertexID 造出来），
+// 逐像素问两句：
+//   1. 这个像素属不属于目镜孔径？不属于 -> discard，主画面原样保留。
+//   2. 属于 -> 从「本帧世界画面的拷贝」里按倍率重采样，输出放大后的世界。
+//
+// 它是 scope_body.fsh 的镜像：那边在孔径内 discard 让路，这边在孔径内落笔。
+// 两者的「孔径判定」必须【逐行一致】，否则会出现一圈既没被镜身画、
+// 也没被 PIP 贴的裂缝。下面那一段就是从 scope_body.fsh 原样搬来的，
+// 改动它时两个文件必须一起改。
+
+#moj_import <minecraft:globals.glsl>
+#moj_import <minecraft:dynamictransforms.glsl>
+
+// 本帧世界画面的拷贝（未含枪与手 —— 拷贝卡在世界画完、视模开画之前）。
+// 名字沿用 vanilla blit 系列的 InSampler，好直接复用 BindGroupLayouts.IN_SAMPLER。
+uniform sampler2D InSampler;
+
+// 目镜掩码：白 = 该像素属于镜内（目镜投影覆盖），黑 = 镜外。
+// 绿通道存开镜进度，见下方收缩逻辑。
+uniform sampler2D ScopeMaskSampler;
+
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+// ---------------------------------------------------------------------------
+// Catmull-Rom 双三次重建（9 抽头版）
+//
+// 镜内画面的放大倍数【就是】瞄具倍率：屏幕上直径 D 的镜片，映射回原画面只有
+// D/Z 个像素，却要铺满 D 个像素。6 倍镜 = 6× 放大。这种量级的放大下，
+// 硬件双线性是最差的选择 —— 它在放大时等价于线性插值，边缘会糊成一片。
+//
+// Catmull-Rom 是插值型三次样条（过样本点、C¹ 连续），放大时明显比双线性锐利，
+// 且不像最近邻那样出块。经典做法是 4×4=16 次点采样，这里用 Matt Pettineo 那套
+// 把每个方向的中间两抽头合并成一次【硬件双线性抽头】的写法，降到 9 次采样 ——
+// 前提是采样器必须是 LINEAR（合成阶段就是这么绑的）。
+//
+// 代价：三次样条会在高对比边缘轻微过冲（振铃），可能产生负值，
+// 所以结果要 max(0.0) 夹一下。
+// ---------------------------------------------------------------------------
+vec3 sampleCatmullRom(sampler2D tex, vec2 uv, vec2 texSize) {
+    vec2 samplePos = uv * texSize;
+    vec2 texPos1 = floor(samplePos - 0.5) + 0.5;
+    vec2 f = samplePos - texPos1;
+
+    // Catmull-Rom 的四个基函数（张力 0.5）
+    vec2 w0 = f * (-0.5 + f * (1.0 - 0.5 * f));
+    vec2 w1 = 1.0 + f * f * (-2.5 + 1.5 * f);
+    vec2 w2 = f * (0.5 + f * (2.0 - 1.5 * f));
+    vec2 w3 = f * f * (-0.5 + 0.5 * f);
+
+    // 中间两抽头合并：用一次偏移过的双线性采样代替两次点采样
+    vec2 w12 = w1 + w2;
+    vec2 offset12 = w2 / max(w12, vec2(1.0e-5));
+
+    vec2 texPos0 = (texPos1 - 1.0) / texSize;
+    vec2 texPos3 = (texPos1 + 2.0) / texSize;
+    vec2 texPos12 = (texPos1 + offset12) / texSize;
+
+    vec3 result = vec3(0.0);
+    result += texture(tex, vec2(texPos0.x,  texPos0.y)).rgb  * w0.x  * w0.y;
+    result += texture(tex, vec2(texPos12.x, texPos0.y)).rgb  * w12.x * w0.y;
+    result += texture(tex, vec2(texPos3.x,  texPos0.y)).rgb  * w3.x  * w0.y;
+
+    result += texture(tex, vec2(texPos0.x,  texPos12.y)).rgb * w0.x  * w12.y;
+    result += texture(tex, vec2(texPos12.x, texPos12.y)).rgb * w12.x * w12.y;
+    result += texture(tex, vec2(texPos3.x,  texPos12.y)).rgb * w3.x  * w12.y;
+
+    result += texture(tex, vec2(texPos0.x,  texPos3.y)).rgb  * w0.x  * w3.y;
+    result += texture(tex, vec2(texPos12.x, texPos3.y)).rgb  * w12.x * w3.y;
+    result += texture(tex, vec2(texPos3.x,  texPos3.y)).rgb  * w3.x  * w3.y;
+
+    return max(result, vec3(0.0));
+}
+
+void main() {
+    // texCoord 与掩码/场景拷贝同为左下原点、同一尺寸比例，
+    // 三者可以直接共用一套归一化坐标，不需要任何翻转或纵横比换算。
+    vec2 maskSample = texture(ScopeMaskSampler, texCoord).rg;
+    bool insideOcular = maskSample.r > 0.5;
+
+    // 【开镜渐进】与 scope_body.fsh 同一份逻辑：沿掩码边缘向内收缩。
+    // 圆心不动、只有覆盖范围随进度增长 —— 这是上游
+    //     rad = 80 * modifier * aimingProgress
+    // 的二维等价物。用掩码自身当距离场，因此对任意形状的目镜投影都成立。
+    if (insideOcular) {
+        float progress = maskSample.g;
+        if (progress < 0.999) {
+            const int RINGS = 3;
+            const int STEPS = 8;
+            float inside = 0.0;
+            float total = 0.0;
+            float unit = 0.055;
+            for (int r = 1; r <= RINGS; r++) {
+                float radius = unit * float(r) / float(RINGS);
+                for (int i = 0; i < STEPS; i++) {
+                    float a = 6.2831853 * float(i) / float(STEPS);
+                    vec2 off = vec2(cos(a), sin(a)) * radius;
+                    off.x *= ScreenSize.y / max(ScreenSize.x, 1.0);
+                    total += 1.0;
+                    inside += texture(ScopeMaskSampler, texCoord + off).r > 0.5 ? 1.0 : 0.0;
+                }
+            }
+            float depth = total > 0.0 ? inside / total : 1.0;
+            if (depth < 1.0 - progress) {
+                insideOcular = false;
+            }
+        }
+    }
+
+    if (!insideOcular) {
+        // 镜外：主画面（未变焦的世界）原样保留。
+        discard;
+    }
+
+    // 【诊断 · ScopePipDebugPaintLens】把合成覆盖到的区域涂成纯品红。
+    //
+    // 「放大画面溢出到镜外」有两种完全不同的成因，成品画面上分不出来：
+    //   ① 合成没被掩码约束住，整屏都画了 —— 那么整个屏幕会变品红；
+    //   ② 合成是对的，溢出来自别处 —— 那么只有镜片是品红。
+    // 涂纯色能一眼看出合成到底盖了多大范围，比「关掉合成看还漏不漏」更直接：
+    // 后者只能告诉你「不是合成」，前者直接把合成的真实覆盖范围画出来。
+    //
+    // 标志走 ColorModulator.b（0 = 诊断，1 = 正常）——
+    // 那个通道本来就是常量 1.0 的空闲载体，不必再动 bind group layout。
+    if (ColorModulator.b < 0.5) {
+        fragColor = vec4(1.0, 0.0, 1.0, 1.0);
+        return;
+    }
+
+    // 【镜内重投影】倍率由 ColorModulator.r 送进来（见 ScopePipRenderer 的合成阶段）。
+    //
+    // 透视投影的恒等关系：把 FOV 压窄 Z 倍，等价于绕光轴把画面放大 Z 倍。
+    //     窄FOV下的 NDC = 宽FOV下的 NDC × Z
+    // 反过来，要知道「窄FOV画面在这个像素上是什么」，就到宽FOV画面的
+    //     center + (uv − center) / Z
+    // 处去取。这不是近似 —— 它与「用窄 FOV 把世界重画一遍」逐像素等价。
+    //
+    // 因为 |uv − center| <= 0.5 且 Z >= 1，采样点必然落在 [0,1] 内，
+    // 不会碰到纹理边界，无需额外 clamp。
+    float magnification = max(ColorModulator.r, 1.0);
+    vec2 center = vec2(0.5);
+    vec2 sceneUv = center + (texCoord - center) / magnification;
+
+    // 重建：双三次而不是双线性，理由见 sampleCatmullRom 的注释。
+    vec3 color = sampleCatmullRom(InSampler, sceneUv, ScreenSize);
+
+    // 【锐化】按倍率加权的钝化蒙版（unsharp mask）。
+    //
+    // 放大倍数就是瞄具倍率，所以低倍镜几乎不需要锐化、高倍镜很需要 ——
+    // 强度随倍率从 1× 的 0 线性升到 6× 的满值，超过 6× 保持满值。
+    // 这样 ACOG 不会被过度处理，8 倍镜也不会锐化不足。
+    //
+    // 抽头取在【源图】的相邻像素上（1/ScreenSize），即「先锐化再放大」：
+    // 高频细节本来就只存在于源图的采样率上，在放大后的坐标系里做邻域
+    // 只会放大插值产生的伪细节，而且每个抽头都要再跑一遍 Catmull-Rom，不划算。
+    float sharpenAmount = ColorModulator.g * clamp((magnification - 1.0) / 5.0, 0.0, 1.0);
+    if (sharpenAmount > 0.001) {
+        vec2 texel = 1.0 / ScreenSize;
+        vec3 blur = texture(InSampler, sceneUv + vec2( texel.x, 0.0)).rgb
+                  + texture(InSampler, sceneUv + vec2(-texel.x, 0.0)).rgb
+                  + texture(InSampler, sceneUv + vec2(0.0,  texel.y)).rgb
+                  + texture(InSampler, sceneUv + vec2(0.0, -texel.y)).rgb;
+        blur *= 0.25;
+        // 经典 unsharp：原图 + k ×（原图 − 模糊）。夹到 0 以上，
+        // 避免在高对比边缘的暗侧被推成负值（叠加 Catmull-Rom 自身的过冲会更明显）。
+        color = max(color + (color - blur) * sharpenAmount, vec3(0.0));
+    }
+
+    // alpha 固定 1.0：管线的写掩码是 WRITE_COLOR，alpha 通道压根不会被写入，
+    // 这里给什么都不影响结果；写 1.0 只是让「这是一块不透明的实心画面」在源码里读得出来。
+    fragColor = vec4(color, 1.0);
+}

--- a/src/main/resources/tacz.mixins.json
+++ b/src/main/resources/tacz.mixins.json
@@ -14,6 +14,7 @@
     "client.CameraMixin",
     "client.FeatureRenderDispatcherMixin",
     "client.GameRendererMixin",
+    "client.SkyRendererMixin",
     "client.ItemInHandLayerMixin",
     "client.ItemInHandRendererMixin",
     "client.LanguageMixin",


### PR DESCRIPTION
<img width="2560" height="1080" alt="2026-08-21_07 27 55" src="https://github.com/user-attachments/assets/9eeccd97-d551-4c9c-ab65-9322e6469b5e" />


<img width="2560" height="1080" alt="2026-08-21_07 27 34" src="https://github.com/user-attachments/assets/6836252a-f071-46ce-9533-cad2cbecc95e" />

![Uploading 2026-08-22_01.29.57.png…]()


Added a picture in picture based Scopes for with and without shaders. 

Without shaders it do a second render so it's a true picture in picture, need sodium with fabric. With shader it's too complicated , so i did only screen space based PIP when shader are active. Need to be enable in `tacz_client.toml` config